### PR TITLE
Adding netmask argument and fixing vip-manager patroni failover bug

### DIFF
--- a/checker/leader_checker.go
+++ b/checker/leader_checker.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 )
 
-var ErrKeyDoesNotExist = errors.New("the configured key does not exist")
 var ErrUnsupportedEndpointType = errors.New("given endpoint type not supported")
 
 type LeaderChecker interface {


### PR DESCRIPTION
During postgresql cluster setup testing with vip-manager i encountered two problems:
- The defaultmask was automatically /8 in my occasion and caused the server to be unreachable
- During a failover it seems that patroni deletes the leader key before readding it again after another leader took over. This caused vip-manager to panic and not doing the ip-reassigning at all

I additionally now added the functionality that it is possible to start vip-manager without the key being visible at all which gives also the possibility to start vip-manager before the cluster is even ready to be faster when spawning a cluster.
I removed also the explicit set of state to false because we thought if anything goes wrong, vip-manager should just do nothing until it gets some reliable information again.