### PR TITLE
Streamline config file location.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Manages a virtual IP based on state kept in etcd or Consul. Monitors state in et
 ## Installing on debian
 
 * Install the debian package. Currently you will have to build the package yourself. Prebuilt packages are coming soon.
-* Edit `/etc/patroni/vip.conf`. See the configuration section for details.
+* Edit `/etc/default/vip-manager`. See the configuration section for details.
 * Start and enable vip-manager service with systemctl.
 
 ## Installing by hand
 
 * Build the vip-manager binary using go. 
 * Install service file from `package/scripts/vip-manager.service` to `/etc/systemd/system/`
-* Install configuration file from `package/config/vip-manager.default` to `/etc/patroni/vip.conf`
+* Install configuration file from `package/config/vip-manager.default` to `/etc/default/vip-manager`
 * Edit config and start the service.
 
 ## Configuration

--- a/package/scripts/vip-manager
+++ b/package/scripts/vip-manager
@@ -125,9 +125,6 @@ if [ ! -d "$piddir" ]; then
     chown $USER:$GROUP $piddir
 fi
 
-# Configuration file
-config=/etc/vip-manager/vip.conf
-
 # If the daemon is not there, then exit.
 [ -x $daemon ] || exit 5
 

--- a/package/scripts/vip-manager.service
+++ b/package/scripts/vip-manager.service
@@ -6,7 +6,7 @@ Before=patroni.service
 [Service]
 Type=simple
 
-EnvironmentFile=-/etc/patroni/vip.conf
+EnvironmentFile=-/etc/default/vip-manager
 
 ExecStart=/bin/bash -c "/usr/bin/vip-manager -ip=\"${VIP_IP}\" -iface=\"${VIP_IFACE}\" -key=\"${VIP_KEY}\" -host=\"${VIP_HOST}\" -type=\"${VIP_TYPE}\" -endpoint=\"${VIP_ENDPOINT}\" -mask=\"${VIP_MASK}\""
 Restart=on-failure


### PR DESCRIPTION
The config file was referenced under different names.

This patch is supposed to streamline it so that it always reference to /etc/default/vip-manager