### PR TITLE
fix more copy/paste bugs in init script

### DIFF
--- a/package/scripts/vip-manager
+++ b/package/scripts/vip-manager
@@ -57,11 +57,11 @@ if [ -z "$VIP_TYPE" ]; then
 fi
 
 if [ -z "$VIP_ENDPOINT" ]; then
-    VIP_OPTS="$VIP_OPTS -type=$VIP_ENDPOINT"
+    VIP_OPTS="$VIP_OPTS -endpoint=$VIP_ENDPOINT"
 fi
 
 if [ -z "$VIP_MASK" ]; then
-    VIP_OPTS="$VIP_OPTS -type=$VIP_MASK"
+    VIP_OPTS="$VIP_OPTS -mask=$VIP_MASK"
 fi
 
 if [ -z "$VIP_HOSTINGTYPE" ]; then


### PR DESCRIPTION
please merge

looking at the patch I think it can be quite safely claimed that the init script hasn't ever been working or tested. So the question is, given that, since it never worked, nobody could have ever used it -> should it be kept?