### PR TITLE
[-] dix `get_dev` in namespaced environments

### DIFF
--- a/test/behaviour_test.sh
+++ b/test/behaviour_test.sh
@@ -13,17 +13,8 @@ function get_dev {
     # select a suitable device for testing purposes
     # * a device that is an "ether"
     # * and isn't a nil hardware address
-
-    # https://www.kernel.org/doc/Documentation/ABI/testing/sysfs-class-net
-    ARPHRD_ETHER=1
-
-    for dev in /sys/class/net/* ; do
-        test ! -e "$dev/address" && continue
-        test "`cat $dev/address`" = "00:00:00:00:00:00" && continue
-        test "`cat $dev/type`" != "$ARPHRD_ETHER" && continue
-        basename "$dev"
-        break
-    done
+    # strip suffix from name (veth3@if8 -> veth3)
+    ip -oneline link show | grep link/ether | grep -v 00:00:00:00:00:00 | cut -d ":" -f2 | cut -d "@" -f 1
 }
 
 dev="`get_dev`"

--- a/test/behaviour_test.sh
+++ b/test/behaviour_test.sh
@@ -14,7 +14,7 @@ function get_dev {
     # * a device that is an "ether"
     # * and isn't a nil hardware address
     # strip suffix from name (veth3@if8 -> veth3)
-    ip -oneline link show | grep link/ether | grep -v 00:00:00:00:00:00 | cut -d ":" -f2 | cut -d "@" -f 1
+    ip -oneline link show | grep link/ether | grep -v 00:00:00:00:00:00 | cut -d ":" -f2 | cut -d "@" -f 1 | head -n1
 }
 
 dev="`get_dev`"


### PR DESCRIPTION
Commit cd9ab2911952ac42 fixed device selection in environments that have
multiple devices, but unfortunately broke it on apt.postgresql.org,
where the tests are running in network namespaces via veth/ceth devices.
This fixes the detection to support both.