### PR TITLE
[-] fix VIP address lookup in IP address list, fixes #125

### DIFF
--- a/ipmanager/basicConfigurer.go
+++ b/ipmanager/basicConfigurer.go
@@ -41,7 +41,7 @@ func (c *BasicConfigurer) queryAddress() bool {
 		return false
 	}
 	for _, address := range addresses {
-		if strings.Contains(address.String(), c.VIP.String()) {
+		if strings.Contains(address.String(), c.getCIDR()) {
 			return true
 		}
 	}


### PR DESCRIPTION
fix [#125 issue](https://github.com/cybertec-postgresql/vip-manager/issues/125)
c.VIP.String() - VIP address without netmask.
c.getCIDR() - VIP address with netmask.
When VIP address is a substring of server's IP address, the vip-manager doesn't rise VIP address because conditions "if strings.Contains(address.String(), c.VIP.String())" returns true. And vip-manager thinks that VIP adress is already up.
For example: 
VIP = 192.168.1.2, server's IP = 192.168.1.210
condition "if strings.Contains(address.String(), c.VIP.String())" will return true because 192.168.1.2 is substring of 19.168.1.210
But address.String() has format like ip_address/netmaks (192.168.1.210/24)
And we have to compare it with VIP adress plus netmask too
And for VIP address we have to use c.getCIDR() that returns vip address with netmask