### PR TITLE
Allow etcd3 as additional spelling of etcd dcs-type.

### DIFF
--- a/checker/leader_checker.go
+++ b/checker/leader_checker.go
@@ -23,7 +23,7 @@ func NewLeaderChecker(con *vipconfig.Config) (LeaderChecker, error) {
 	switch con.EndpointType {
 	case "consul":
 		lc, err = NewConsulLeaderChecker(con)
-	case "etcd":
+	case "etcd", "etcd3":
 		lc, err = NewEtcdLeaderChecker(con)
 	default:
 		err = ErrUnsupportedEndpointType

--- a/vipconfig/config.go
+++ b/vipconfig/config.go
@@ -301,7 +301,7 @@ func NewConfig() (*Config, error) {
 		switch viper.GetString("dcs-type") {
 		case "consul":
 			viper.Set("dcs-endpoints", []string{"http://127.0.0.1:8500"})
-		case "etcd":
+		case "etcd", "etcd3":
 			viper.Set("dcs-endpoints", []string{"http://127.0.0.1:2379"})
 		}
 	}


### PR DESCRIPTION
This adds support to specify the V3 API etcd dcs-type as "etcd3" as well. Patroni uses this string to differentiate between V2 ("etcd") and V3 ("etcd3") APIs, so allowing this makes it possible to use the same string both in Patroni and vip-manager.