### PR TITLE
[*] update the `version` variable default value to match the current release v2.4.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ import (
 
 var (
 	// vip-manager version definition
-	version = "2.0.0"
+	version = "2.4.0"
 )
 
 func getMask(vip netip.Addr, mask int) net.IPMask {


### PR DESCRIPTION
The version number remains 2.0.0 while the the release number has upgraded to v2.4.0. We suggest to update the version number along with the release number to avoid version confusion.