### PR TITLE
[-] mark config file as "noreplace" so it won't be overwritten by rpm updates

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,7 +65,7 @@ nfpms:
     contents:
       - src: vipconfig/vip-manager.yml
         dst: /etc/default/vip-manager.yml
-        type: config
+        type: "config|noreplace"
 
       - src: vip-manager.service
         dst: /lib/systemd/system/vip-manager.service


### PR DESCRIPTION
According to the nfpm docs a config file must be marked "noreplace", otherwise it will be overwritten when updating the rpm package.

See: 
https://goreleaser.com/customization/nfpm/
https://www.cl.cam.ac.uk/~jw35/docs/rpm_config.html