### PR TITLE
Use /leader as default trigger key for Patroni DCS type

### DIFF
--- a/vipconfig/config.go
+++ b/vipconfig/config.go
@@ -310,6 +310,14 @@ func NewConfig() (*Config, error) {
 		}
 	}
 
+	// set trigger-key to '/leader' if DCS type is patroni and nothing is specified
+	if triggerKey := viper.GetString("trigger-key"); len(triggerKey) == 0 {
+		if viper.GetString("dcs-type") == "patroni" {
+			triggerKey = "/leader"
+			viper.Set("trigger-key", triggerKey)
+		}
+	}
+
 	// set trigger-value to default value if nothing is specified
 	if triggerValue := viper.GetString("trigger-value"); len(triggerValue) == 0 {
 		if viper.GetString("dcs-type") == "patroni" {


### PR DESCRIPTION
AFAICT, `dcs-type=patroni`  has useful `trigger-value`  (200) and `dcs-endpoints` (`http://127.0.0.1:8008`) defaults, but none for `trigger-key`. The `--help` output suggests `/leader` (`leader` without leading slash works as well), and I am not sure it makes a lot of sense to use anything else than `/leader`? Or at least, I think that is a useful default, so I implemented it in the attached PR.