### PR TITLE
[-] fix `--retry-num` parameter handling, fixes #272

### DIFF
--- a/vipconfig/config.go
+++ b/vipconfig/config.go
@@ -72,6 +72,9 @@ func defineFlags() {
 	pflag.String("interval", "1000", "DCS scan interval in milliseconds.")
 	pflag.String("manager-type", "basic", "Type of VIP-management to be used. Supported values: basic, hetzner.")
 
+	pflag.String("retry-after", "250", "Time to wait before retrying interactions with outside components in milliseconds.")
+	pflag.String("retry-num", "3", "Number of times interactions with outside components are retried.")
+
 	pflag.Bool("verbose", false, "Be verbose. Currently only implemented for manager-type=hetzner .")
 
 	pflag.CommandLine.SortFlags = false
@@ -199,6 +202,11 @@ func setDefaults() {
 			fmt.Printf("No trigger-value specified, instead using: %v", triggerValue)
 			viper.Set("trigger-value", triggerValue)
 		}
+	}
+
+	// set retry-num to default if not set or set to zero
+	if retryNum := viper.GetString("retry-num"); retryNum == "" || retryNum == "0" {
+		viper.Set("retry-num", 3)
 	}
 }
 

--- a/vipconfig/config.go
+++ b/vipconfig/config.go
@@ -69,11 +69,11 @@ func defineFlags() {
 
 	pflag.String("consul-token", "", "Token for consul DCS endpoints.")
 
-	pflag.String("interval", "1000", "DCS scan interval in milliseconds.")
+	pflag.Int("interval", 1000, "DCS scan interval in milliseconds.")
 	pflag.String("manager-type", "basic", "Type of VIP-management to be used. Supported values: basic, hetzner.")
 
-	pflag.String("retry-after", "250", "Time to wait before retrying interactions with outside components in milliseconds.")
-	pflag.String("retry-num", "3", "Number of times interactions with outside components are retried.")
+	pflag.Int("retry-after", 250, "Time to wait before retrying interactions with outside components in milliseconds.")
+	pflag.Int("retry-num", 3, "Number of times interactions with outside components are retried.")
 
 	pflag.Bool("verbose", false, "Be verbose. Currently only implemented for manager-type=hetzner .")
 
@@ -156,12 +156,12 @@ func mapDeprecated() error {
 }
 
 func setDefaults() {
-	defaults := map[string]string{
-		"dcs-type":    "etcd",
-		"interval":    "1000",
+	defaults := map[string]any{
 		"hostingtype": "basic",
-		"retry-num":   "3",
-		"retry-after": "250",
+		"dcs-type":    "etcd",
+		"interval":    1000,
+		"retry-after": 250,
+		"retry-num":   3,
 	}
 
 	for k, v := range defaults {
@@ -205,7 +205,7 @@ func setDefaults() {
 	}
 
 	// set retry-num to default if not set or set to zero
-	if retryNum := viper.GetString("retry-num"); retryNum == "" || retryNum == "0" {
+	if retryNum := viper.GetInt("retry-num"); retryNum <= 0 {
 		viper.Set("retry-num", 3)
 	}
 }


### PR DESCRIPTION
This introduces --retry-num and --retry-after command-line parameters
and makes sure the value for `retry-num' is more than zero as otherwise
the ARP client is not being launched.
Author: @mbanck-ntap 