### PR TITLE
[+] add TLS support to patroni leader checker

### DIFF
--- a/checker/patroni_leader_checker.go
+++ b/checker/patroni_leader_checker.go
@@ -20,15 +20,13 @@ type PatroniLeaderChecker struct {
 
 // NewPatroniLeaderChecker returns a new instance
 func NewPatroniLeaderChecker(conf *vipconfig.Config) (*PatroniLeaderChecker, error) {
-
 	tlsConfig, err := getTransport(conf)
 	if err != nil {
 		return nil, err
 	}
 
-	transport := &http.Transport{}
-        if tlsConfig != nil {
-		transport.TLSClientConfig = tlsConfig
+	transport := &http.Transport{
+		TLSClientConfig: tlsConfig,
 	}
 
 	client := &http.Client{


### PR DESCRIPTION
I added TLS support for Patroni Leader Checker.

NB : I reused the getTransport method of etcd_leader_checker.go so Patroni Leader Checker gets its parameter values from etcd-ca-file, etcd-cert-file, etcd-key-file.