### PR TITLE
[+] add `ppc64le` support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,7 @@ archives:
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
+      {{- else if eq .Arch "ppc64le" }}ppy64le
       {{- else }}{{ .Arch }}{{ end }}
   wrap_in_directory: true
   format_overrides:
@@ -48,6 +49,7 @@ nfpms:
       {{- title .Os }}_
       {{- if eq .Arch "amd64" }}x86_64
       {{- else if eq .Arch "386" }}i386
+      {{- else if eq .Arch "ppc64le" }}ppy64le
       {{- else }}{{ .Arch }}{{ end }}
 
     vendor: CYBERTEC PostgreSQL International GmbH

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ install:
 DESTDIR=tmp
 
 package: 
-	goreleaser release --snapshot --skip-publish --rm-dist
+	goreleaser release --snapshot --skip=publish --clean 
 
 clean:
 	$(RM) vip-manager


### PR DESCRIPTION
Hello 

here are my changes to compile it to IBM Power(ppc64le) as well.  @pashagolub


https://github.com/cybertec-postgresql/vip-manager/issues/367

On my build host everything looks pretty good so far. Do you have access to a ppc64le server?


```
# make package
goreleaser release --snapshot --skip=publish --clean
  • starting release
  • skipping announce, publish, and validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • using tags                                     previous=v3.0.0 current=v4.0.0
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • snapshotting
    • building snapshot...                           version=4.0.0-SNAPSHOT-fb25794
  • running before hooks
    • running                                        hook=go mod tidy
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • running hook                                   hook=go generate ./...
    • running hook                                   hook=go generate ./...
    • running hook                                   hook=go generate ./...
    • running hook                                   hook=go generate ./...
    • running hook                                   hook=go generate ./...
    • running hook                                   hook=go generate ./...
    • building                                       paths=. binaries=vip-manager target=windows_arm64_v8.0
    • building                                       paths=. binaries=vip-manager target=windows_amd64_v1
    • building                                       paths=. binaries=vip-manager target=windows_386_sse2
    • building                                       paths=. binaries=vip-manager target=linux_arm64_v8.0
    • building                                       paths=. binaries=vip-manager target=linux_386_sse2
    • building                                       paths=. binaries=vip-manager target=linux_amd64_v1
  • archives
    • archiving                                      name=dist/vip-manager_4.0.0-SNAPSHOT-fb25794_Linux_x86_64.tar.gz
    • archiving                                      name=dist/vip-manager_4.0.0-SNAPSHOT-fb25794_Windows_arm64.zip
    • archiving                                      name=dist/vip-manager_4.0.0-SNAPSHOT-fb25794_Windows_x86_64.zip
    • archiving                                      name=dist/vip-manager_4.0.0-SNAPSHOT-fb25794_Linux_i386.tar.gz
    • archiving                                      name=dist/vip-manager_4.0.0-SNAPSHOT-fb25794_Windows_i386.zip
    • archiving                                      name=dist/vip-manager_4.0.0-SNAPSHOT-fb25794_Linux_arm64.tar.gz
      • took: 14s
  • linux packages
    • creating                                       package=vip-manager format=rpm arch=amd64v1 file=dist/vip-manager_4.0.0-SNAPSHOT-fb25794_Linux_x86_64.rpm
    • creating                                       package=vip-manager format=deb arch=386sse2 file=dist/vip-manager_4.0.0-SNAPSHOT-fb25794_Linux_i386.deb
    • creating                                       package=vip-manager format=deb arch=arm64v8.0 file=dist/vip-manager_4.0.0-SNAPSHOT-fb25794_Linux_arm64.deb
    • creating                                       package=vip-manager format=deb arch=amd64v1 file=dist/vip-manager_4.0.0-SNAPSHOT-fb25794_Linux_x86_64.deb
    • creating                                       package=vip-manager format=rpm arch=386sse2 file=dist/vip-manager_4.0.0-SNAPSHOT-fb25794_Linux_i386.rpm
    • creating                                       package=vip-manager format=rpm arch=arm64v8.0 file=dist/vip-manager_4.0.0-SNAPSHOT-fb25794_Linux_arm64.rpm
      • took: 12s
  • calculating checksums
  • writing artifacts metadata
  • release succeeded after 33s
  • thanks for using GoReleaser!

```