### PR TITLE
[*] update default `retry-num` config to match code default

### DIFF
--- a/vipconfig/vip-manager.yml
+++ b/vipconfig/vip-manager.yml
@@ -36,7 +36,7 @@ etcd-key-file: "/path/to/etcd/client/key/file"
 consul-token: "Julian's secret token"
 
 # how often things should be retried and how long to wait between retries. (currently only affects arpClient)
-retry-num: 2
+retry-num: 3
 retry-after: 250  #in milliseconds
 
 # verbose logs (currently only supported for hetzner)


### PR DESCRIPTION
Default in code was `3`, but in the example config file it was `2`.  Updated config file to match code.