### PR TITLE
feat(logging): add --log-file option and catch SIGHUP to reopen

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ This is a list of all available configuration items:
 | `etcd-cert-file`  | `VIP_ETCD_CERT_FILE`  | no        | `/etc/etcd/client.cert.pem` | A client certificate that is used to authenticate against etcd endpoints. Requires `etcd-ca-file` to be set as well. |
 | `etcd-key-file`   | `VIP_ETCD_KEY_FILE`   | no        | `/etc/etcd/client.key.pem`  | A private key for the client certificate, used to decrypt messages sent by etcd endpoints. Required when `etcd-cert-file` is specified. |
 | `verbose`         | `VIP_VERBOSE`         | no        | `true`                      | Enable more verbose logging. Currently only the manager-type=hetzner provides additional logs. |
+| `log-file`        | `VIP_LOG_FILE`        | no        | `/var/log/vip-manager.log`  | Path to a log file. When set, logs are written to this file instead of stdout. Send `SIGHUP` to make vip-manager close and reopen the file, so log-rotation tools such as `logrotate` can rotate it. When empty (the default), logs go to stdout (and thus the systemd journal). |
 
 ## Configuration - Patroni REST API
 
@@ -178,6 +179,37 @@ Either:
 
 > [!NOTE]
 > Currently only supported for `hetzner`
+
+## Log rotation
+
+By default vip-manager logs to stdout, so under systemd the logs end up in the
+journal, which handles its own rotation. If you instead configure an explicit
+log file with `log-file` (e.g. `VIP_LOG_FILE=/var/log/vip-manager.log`), you are
+responsible for rotating that file.
+
+vip-manager follows the usual daemon convention: on `SIGHUP` it closes and
+reopens the configured log file. This lets `logrotate` move the current file
+aside and have vip-manager start writing to a freshly created file, so the old,
+rotated file can be compressed/removed and storage is not filled over time.
+
+Example `/etc/logrotate.d/vip-manager`:
+
+```text
+/var/log/vip-manager.log {
+    daily
+    rotate 7
+    compress
+    delaycompress
+    missingok
+    notifempty
+    postrotate
+        systemctl kill -s HUP vip-manager.service 2>/dev/null || true
+    endscript
+}
+```
+
+If you don't run under systemd, replace the `postrotate` command with a plain
+`kill -HUP $(cat /run/vip-manager.pid)` (or however you track the PID).
 
 ## Author
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This is a list of all available configuration items:
 | `etcd-cert-file`  | `VIP_ETCD_CERT_FILE`  | no        | `/etc/etcd/client.cert.pem` | A client certificate that is used to authenticate against etcd endpoints. Requires `etcd-ca-file` to be set as well. |
 | `etcd-key-file`   | `VIP_ETCD_KEY_FILE`   | no        | `/etc/etcd/client.key.pem`  | A private key for the client certificate, used to decrypt messages sent by etcd endpoints. Required when `etcd-cert-file` is specified. |
 | `verbose`         | `VIP_VERBOSE`         | no        | `true`                      | Enable more verbose logging. Currently only the manager-type=hetzner provides additional logs. |
-| `log-file`        | `VIP_LOG_FILE`        | no        | `/var/log/vip-manager.log`  | Path to a log file. When set, logs are written to this file instead of stdout. Send `SIGHUP` to make vip-manager close and reopen the file, so log-rotation tools such as `logrotate` can rotate it. When empty (the default), logs go to stdout (and thus the systemd journal). |
+| `log-file`        | `VIP_LOG_FILE`        | no        | `/var/log/vip-manager.log`  | Path to a log file. When set, logs are written to this file instead of stdout, and the process's stdout and stderr are redirected to it as well (so panics and any other output are also captured). Send `SIGHUP` to make vip-manager close and reopen the file, so log-rotation tools such as `logrotate` can rotate it. When empty (the default), logs go to stdout (and thus the systemd journal). |
 
 ## Configuration - Patroni REST API
 
@@ -187,10 +187,15 @@ journal, which handles its own rotation. If you instead configure an explicit
 log file with `log-file` (e.g. `VIP_LOG_FILE=/var/log/vip-manager.log`), you are
 responsible for rotating that file.
 
+When `log-file` is set, vip-manager also redirects its own stdout and stderr to
+that file, so runtime panics and any other output not routed through the logger
+end up in the same place.
+
 vip-manager follows the usual daemon convention: on `SIGHUP` it closes and
-reopens the configured log file. This lets `logrotate` move the current file
-aside and have vip-manager start writing to a freshly created file, so the old,
-rotated file can be compressed/removed and storage is not filled over time.
+reopens the configured log file (re-applying the stdout/stderr redirect to the
+new file). This lets `logrotate` move the current file aside and have
+vip-manager start writing to a freshly created file, so the old, rotated file
+can be compressed/removed and storage is not filled over time.
 
 Example `/etc/logrotate.d/vip-manager`:
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"sync"
+	"syscall"
 
 	"github.com/cybertec-postgresql/vip-manager/checker"
 	"github.com/cybertec-postgresql/vip-manager/ipmanager"
@@ -52,10 +53,21 @@ func main() {
 
 	go func() {
 		c := make(chan os.Signal, 1)
-		signal.Notify(c, os.Interrupt)
-		<-c
-		log.Info("Received exit signal")
-		cancel()
+		signal.Notify(c, os.Interrupt, syscall.SIGHUP)
+		for sig := range c {
+			if sig == syscall.SIGHUP {
+				// Reopen the log file so that logrotate (via "systemctl kill
+				// -s HUP") can move the current file aside. No-op on stdout.
+				log.Info("Received SIGHUP, reopening log file")
+				if err := conf.ReopenLog(); err != nil {
+					log.Errorf("Failed to reopen log file: %s", err)
+				}
+				continue
+			}
+			log.Info("Received exit signal")
+			cancel()
+			return
+		}
 	}()
 
 	var wg sync.WaitGroup

--- a/vipconfig/config.go
+++ b/vipconfig/config.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -42,7 +43,13 @@ type Config struct {
 
 	Verbose bool `mapstructure:"verbose"`
 
+	LogFile string `mapstructure:"log-file"`
+
 	Logger *zap.Logger
+
+	// logReopener is set when logging to a file so that the file can be closed
+	// and reopened on SIGHUP (see ReopenLog). It is nil when logging to stdout.
+	logReopener *reopenableFile
 }
 
 func defineFlags() *pflag.FlagSet {
@@ -78,6 +85,8 @@ func defineFlags() *pflag.FlagSet {
 	flags.Int("retry-num", 3, "Number of times interactions with outside components are retried.")
 
 	flags.Bool("verbose", false, "Be verbose. Currently only implemented for manager-type=hetzner .")
+
+	flags.String("log-file", "", "Path to a log file. If empty, logs are written to stdout. Send SIGHUP to reopen the file after rotation (e.g. logrotate).")
 
 	flags.SortFlags = false
 	return flags
@@ -285,44 +294,81 @@ func newConfig(args []string) (*Config, error) {
 }
 
 func (conf *Config) initLogger() {
-	lcfg := zap.Config{
-		Level: zap.NewAtomicLevelAt(map[bool]zapcore.Level{
-			false: zap.InfoLevel,
-			true:  zap.DebugLevel}[conf.Verbose]),
+	level := zap.NewAtomicLevelAt(map[bool]zapcore.Level{
+		false: zap.InfoLevel,
+		true:  zap.DebugLevel}[conf.Verbose])
 
-		Development: false,
+	// copied from "zap.NewProductionEncoderConfig" with some updates
+	encoderConfig := zapcore.EncoderConfig{
+		TimeKey:        "ts",
+		LevelKey:       "level",
+		NameKey:        "logger",
+		CallerKey:      "caller",
+		MessageKey:     "msg",
+		StacktraceKey:  "stacktrace",
+		LineEnding:     zapcore.DefaultLineEnding,
+		EncodeLevel:    zapcore.CapitalColorLevelEncoder,
+		EncodeTime:     zapcore.ISO8601TimeEncoder,
+		EncodeDuration: zapcore.StringDurationEncoder,
 
-		Sampling: &zap.SamplingConfig{
-			Initial:    100,
-			Thereafter: 100,
-		},
-		Encoding: "console",
-
-		// copied from "zap.NewProductionEncoderConfig" with some updates
-		EncoderConfig: zapcore.EncoderConfig{
-			TimeKey:        "ts",
-			LevelKey:       "level",
-			NameKey:        "logger",
-			CallerKey:      "caller",
-			MessageKey:     "msg",
-			StacktraceKey:  "stacktrace",
-			LineEnding:     zapcore.DefaultLineEnding,
-			EncodeLevel:    zapcore.CapitalColorLevelEncoder,
-			EncodeTime:     zapcore.ISO8601TimeEncoder,
-			EncodeDuration: zapcore.StringDurationEncoder,
-
-			EncodeCaller: map[bool]zapcore.CallerEncoder{
-				false: nil,
-				true:  zapcore.ShortCallerEncoder}[conf.Verbose],
-		},
-
-		// Use "/dev/null" to discard all
-		OutputPaths:      []string{"stdout"},
-		ErrorOutputPaths: []string{"stderr"},
+		EncodeCaller: map[bool]zapcore.CallerEncoder{
+			false: nil,
+			true:  zapcore.ShortCallerEncoder}[conf.Verbose],
 	}
-	var err error
-	conf.Logger, err = lcfg.Build()
+
+	// When no log file is configured, keep the original stdout behaviour.
+	if conf.LogFile == "" {
+		lcfg := zap.Config{
+			Level:       level,
+			Development: false,
+			Sampling: &zap.SamplingConfig{
+				Initial:    100,
+				Thereafter: 100,
+			},
+			Encoding:      "console",
+			EncoderConfig: encoderConfig,
+
+			// Use "/dev/null" to discard all
+			OutputPaths:      []string{"stdout"},
+			ErrorOutputPaths: []string{"stderr"},
+		}
+		var err error
+		conf.Logger, err = lcfg.Build()
+		if err != nil {
+			panic(err)
+		}
+		return
+	}
+
+	// A log file is configured: build the core manually so that we control the
+	// underlying writer and can close/reopen it on SIGHUP (see ReopenLog).
+	reopener, err := newReopenableFile(conf.LogFile)
 	if err != nil {
 		panic(err)
 	}
+	conf.logReopener = reopener
+
+	// ANSI colour codes do not belong in a log file, so use the plain encoder.
+	encoderConfig.EncodeLevel = zapcore.CapitalLevelEncoder
+
+	core := zapcore.NewCore(
+		zapcore.NewConsoleEncoder(encoderConfig),
+		zapcore.AddSync(reopener),
+		level,
+	)
+	// Match the sampling used by the stdout logger above.
+	core = zapcore.NewSamplerWithOptions(core, time.Second, 100, 100)
+
+	// AddCaller + AddStacktrace mirror what zap.Config.Build() adds by default.
+	conf.Logger = zap.New(core, zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel))
+}
+
+// ReopenLog closes and reopens the configured log file so log-rotation tools
+// (e.g. logrotate) can move the current file aside and have vip-manager write
+// to a freshly created file. It is a no-op when logging to stdout.
+func (conf *Config) ReopenLog() error {
+	if conf.logReopener == nil {
+		return nil
+	}
+	return conf.logReopener.Reopen()
 }

--- a/vipconfig/config.go
+++ b/vipconfig/config.go
@@ -342,7 +342,9 @@ func (conf *Config) initLogger() {
 
 	// A log file is configured: build the core manually so that we control the
 	// underlying writer and can close/reopen it on SIGHUP (see ReopenLog).
-	reopener, err := newReopenableFile(conf.LogFile)
+	// captureStd=true also redirects the process's stdout/stderr to the file, so
+	// that panics and any output not routed through the logger are captured too.
+	reopener, err := newReopenableFile(conf.LogFile, true)
 	if err != nil {
 		panic(err)
 	}

--- a/vipconfig/config_test.go
+++ b/vipconfig/config_test.go
@@ -378,6 +378,76 @@ func TestInitLogger_Verbose(t *testing.T) {
 	_ = conf.Logger.Sync()
 }
 
+func TestInitLogger_WritesToLogFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vip-manager.log")
+	conf := &Config{LogFile: path}
+	conf.initLogger()
+	if conf.Logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+	if conf.logReopener == nil {
+		t.Fatal("expected logReopener to be set when LogFile is configured")
+	}
+
+	conf.Logger.Info("hello from the log file")
+	_ = conf.Logger.Sync()
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	if !strings.Contains(string(content), "hello from the log file") {
+		t.Errorf("expected logged message in file, got %q", content)
+	}
+	// The file encoder must not embed ANSI colour codes.
+	if strings.Contains(string(content), "\x1b[") {
+		t.Errorf("log file should not contain ANSI colour codes, got %q", content)
+	}
+}
+
+func TestReopenLog_NoLogFileIsNoop(t *testing.T) {
+	conf := &Config{}
+	conf.initLogger()
+	if conf.logReopener != nil {
+		t.Fatal("expected nil logReopener when logging to stdout")
+	}
+	if err := conf.ReopenLog(); err != nil {
+		t.Errorf("expected nil error from ReopenLog in stdout mode, got %v", err)
+	}
+}
+
+func TestReopenLog_WithLogFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "vip-manager.log")
+	conf := &Config{LogFile: path}
+	conf.initLogger()
+
+	conf.Logger.Info("before reopen")
+	_ = conf.Logger.Sync()
+
+	// Simulate logrotate renaming the file, then ask vip-manager to reopen.
+	rotated := path + ".1"
+	if err := os.Rename(path, rotated); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+	if err := conf.ReopenLog(); err != nil {
+		t.Fatalf("ReopenLog: %v", err)
+	}
+
+	conf.Logger.Info("after reopen")
+	_ = conf.Logger.Sync()
+
+	fresh, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read fresh log file: %v", err)
+	}
+	if !strings.Contains(string(fresh), "after reopen") {
+		t.Errorf("expected post-reopen message in fresh file, got %q", fresh)
+	}
+	if strings.Contains(string(fresh), "before reopen") {
+		t.Errorf("fresh file should not contain pre-reopen message, got %q", fresh)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // defineFlags
 // ---------------------------------------------------------------------------
@@ -393,6 +463,7 @@ func TestDefineFlags_AllFlagsPresent(t *testing.T) {
 		"interval", "manager-type",
 		"retry-after", "retry-num",
 		"verbose",
+		"log-file",
 	}
 	flags := defineFlags()
 	for _, name := range expected {
@@ -551,5 +622,23 @@ func TestNewConfig_InvalidFlag(t *testing.T) {
 	_, err := newConfig([]string{"--nonexistent-flag=value"})
 	if err == nil {
 		t.Error("expected error for unknown flag")
+	}
+}
+
+func TestNewConfig_LogFileFlag(t *testing.T) {
+	path := minimalConfigFile(t)
+	logPath := filepath.Join(t.TempDir(), "vip-manager.log")
+	conf, err := newConfig([]string{
+		fmt.Sprintf("--config=%s", path),
+		fmt.Sprintf("--log-file=%s", logPath),
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if conf.LogFile != logPath {
+		t.Errorf("LogFile: got %q, want %q", conf.LogFile, logPath)
+	}
+	if conf.logReopener == nil {
+		t.Error("expected logReopener to be set when --log-file is passed")
 	}
 }

--- a/vipconfig/logfile.go
+++ b/vipconfig/logfile.go
@@ -13,17 +13,31 @@ import (
 type reopenableFile struct {
 	path string
 	mu   sync.Mutex // guards f; Reopen may race with Write/Sync from log goroutines
-	f    *os.File
+
+	// captureStd, when true, redirects the process's stdout/stderr file
+	// descriptors to the log file whenever it is (re)opened, so that panics and
+	// any output not routed through the logger are also captured.
+	captureStd bool
+	f          *os.File
 }
 
 // newReopenableFile opens (creating if necessary) the log file at path in append
 // mode and returns a reopenableFile ready to be used as a zapcore.WriteSyncer.
-func newReopenableFile(path string) (*reopenableFile, error) {
+// When captureStd is true, the process's stdout and stderr are redirected to the
+// file as well (see redirectStdStreams).
+func newReopenableFile(path string, captureStd bool) (*reopenableFile, error) {
 	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		return nil, err
 	}
-	return &reopenableFile{path: path, f: f}, nil
+	r := &reopenableFile{path: path, captureStd: captureStd, f: f}
+	if captureStd {
+		if err := redirectStdStreams(f); err != nil {
+			_ = f.Close()
+			return nil, err
+		}
+	}
+	return r, nil
 }
 
 // Write implements io.Writer.
@@ -56,5 +70,8 @@ func (r *reopenableFile) Reopen() error {
 		return err
 	}
 	r.f = f
+	if r.captureStd {
+		return redirectStdStreams(f)
+	}
 	return nil
 }

--- a/vipconfig/logfile.go
+++ b/vipconfig/logfile.go
@@ -1,0 +1,60 @@
+package vipconfig
+
+import (
+	"os"
+	"sync"
+)
+
+// reopenableFile is a zapcore.WriteSyncer that wraps a log file and can close
+// and reopen it on demand. This allows log-rotation tools such as logrotate to
+// move the current log file aside and have vip-manager start writing to a fresh
+// file (created by logrotate) after receiving a SIGHUP, instead of continuing to
+// write to the now-unlinked inode.
+type reopenableFile struct {
+	path string
+	mu   sync.Mutex // guards f; Reopen may race with Write/Sync from log goroutines
+	f    *os.File
+}
+
+// newReopenableFile opens (creating if necessary) the log file at path in append
+// mode and returns a reopenableFile ready to be used as a zapcore.WriteSyncer.
+func newReopenableFile(path string) (*reopenableFile, error) {
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return nil, err
+	}
+	return &reopenableFile{path: path, f: f}, nil
+}
+
+// Write implements io.Writer.
+func (r *reopenableFile) Write(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.f.Write(p)
+}
+
+// Sync implements zapcore.WriteSyncer by flushing the underlying file.
+func (r *reopenableFile) Sync() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.f.Sync()
+}
+
+// Reopen flushes and closes the current log file, then opens the configured path
+// again. After logrotate has renamed the old file, this makes vip-manager write
+// to the newly created file. The old handle is always closed, even if reopening
+// the path fails.
+func (r *reopenableFile) Reopen() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	_ = r.f.Sync()
+	_ = r.f.Close()
+
+	f, err := os.OpenFile(r.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	r.f = f
+	return nil
+}

--- a/vipconfig/logfile_test.go
+++ b/vipconfig/logfile_test.go
@@ -15,7 +15,7 @@ func TestReopenableFile_ReopenSwapsInode(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "vip-manager.log")
 
-	rf, err := newReopenableFile(path)
+	rf, err := newReopenableFile(path, false)
 	if err != nil {
 		t.Fatalf("newReopenableFile: %v", err)
 	}
@@ -68,7 +68,7 @@ func TestReopenableFile_AppendsToExisting(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	rf, err := newReopenableFile(path)
+	rf, err := newReopenableFile(path, false)
 	if err != nil {
 		t.Fatalf("newReopenableFile: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestReopenableFile_AppendsToExisting(t *testing.T) {
 func TestReopenableFile_NewFileError(t *testing.T) {
 	// A path whose parent directory does not exist must fail to open.
 	path := filepath.Join(t.TempDir(), "nonexistent-dir", "vip-manager.log")
-	if _, err := newReopenableFile(path); err == nil {
+	if _, err := newReopenableFile(path, false); err == nil {
 		t.Error("expected error opening file in nonexistent directory")
 	}
 }

--- a/vipconfig/logfile_test.go
+++ b/vipconfig/logfile_test.go
@@ -1,0 +1,101 @@
+package vipconfig
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestReopenableFile_ReopenSwapsInode verifies the core log-rotation behaviour:
+// after the current file is renamed aside (as logrotate would do), Reopen makes
+// subsequent writes land in a freshly created file at the original path, while
+// the renamed file keeps only what was written before the reopen.
+func TestReopenableFile_ReopenSwapsInode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vip-manager.log")
+
+	rf, err := newReopenableFile(path)
+	if err != nil {
+		t.Fatalf("newReopenableFile: %v", err)
+	}
+
+	if _, err := rf.Write([]byte("before-rotate\n")); err != nil {
+		t.Fatalf("write before rotate: %v", err)
+	}
+	if err := rf.Sync(); err != nil {
+		t.Fatalf("sync: %v", err)
+	}
+
+	// Simulate logrotate moving the current file out of the way.
+	rotated := path + ".1"
+	if err := os.Rename(path, rotated); err != nil {
+		t.Fatalf("rename: %v", err)
+	}
+
+	if err := rf.Reopen(); err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+
+	if _, err := rf.Write([]byte("after-rotate\n")); err != nil {
+		t.Fatalf("write after rotate: %v", err)
+	}
+	if err := rf.Sync(); err != nil {
+		t.Fatalf("sync after rotate: %v", err)
+	}
+
+	rotatedContent := readFile(t, rotated)
+	if !strings.Contains(rotatedContent, "before-rotate") {
+		t.Errorf("rotated file should contain pre-rotate line, got %q", rotatedContent)
+	}
+	if strings.Contains(rotatedContent, "after-rotate") {
+		t.Errorf("rotated file should NOT contain post-rotate line, got %q", rotatedContent)
+	}
+
+	freshContent := readFile(t, path)
+	if !strings.Contains(freshContent, "after-rotate") {
+		t.Errorf("fresh file should contain post-rotate line, got %q", freshContent)
+	}
+	if strings.Contains(freshContent, "before-rotate") {
+		t.Errorf("fresh file should NOT contain pre-rotate line, got %q", freshContent)
+	}
+}
+
+func TestReopenableFile_AppendsToExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "vip-manager.log")
+	if err := os.WriteFile(path, []byte("existing\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rf, err := newReopenableFile(path)
+	if err != nil {
+		t.Fatalf("newReopenableFile: %v", err)
+	}
+	if _, err := rf.Write([]byte("added\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_ = rf.Sync()
+
+	content := readFile(t, path)
+	if !strings.Contains(content, "existing") || !strings.Contains(content, "added") {
+		t.Errorf("expected both existing and added content, got %q", content)
+	}
+}
+
+func TestReopenableFile_NewFileError(t *testing.T) {
+	// A path whose parent directory does not exist must fail to open.
+	path := filepath.Join(t.TempDir(), "nonexistent-dir", "vip-manager.log")
+	if _, err := newReopenableFile(path); err == nil {
+		t.Error("expected error opening file in nonexistent directory")
+	}
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(b)
+}

--- a/vipconfig/redirect_test.go
+++ b/vipconfig/redirect_test.go
@@ -1,0 +1,50 @@
+//go:build !windows
+
+package vipconfig
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCaptureStdStreams_Subprocess verifies that opening a reopenableFile with
+// captureStd=true redirects the process's stdout and stderr file descriptors to
+// the log file, so that plain fmt.Print / os.Stderr writes (which do not go
+// through zap) are also captured. Because the redirect mutates the process-wide
+// fd 1 and 2, the actual work runs in a subprocess (re-executing this test
+// binary with a helper env var set) so it cannot disturb the test runner.
+func TestCaptureStdStreams_Subprocess(t *testing.T) {
+	logPath := os.Getenv("VIPCONFIG_REDIRECT_TEST_LOG")
+	if logPath != "" {
+		// Child mode: perform the redirect and emit to stdout and stderr.
+		rf, err := newReopenableFile(logPath, true)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "newReopenableFile: %v\n", err)
+			os.Exit(2)
+		}
+		fmt.Fprintln(os.Stdout, "captured-stdout-line")
+		fmt.Fprintln(os.Stderr, "captured-stderr-line")
+		_ = rf.Sync()
+		os.Exit(0)
+	}
+
+	// Parent mode: re-exec this test binary running only the child branch.
+	logPath = filepath.Join(t.TempDir(), "vip-manager.log")
+	cmd := exec.Command(os.Args[0], "-test.run=TestCaptureStdStreams_Subprocess")
+	cmd.Env = append(os.Environ(), "VIPCONFIG_REDIRECT_TEST_LOG="+logPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("child process failed: %v\noutput: %s", err, out)
+	}
+
+	content := readFile(t, logPath)
+	if !strings.Contains(content, "captured-stdout-line") {
+		t.Errorf("expected stdout write to be captured in log file, got %q", content)
+	}
+	if !strings.Contains(content, "captured-stderr-line") {
+		t.Errorf("expected stderr write to be captured in log file, got %q", content)
+	}
+}

--- a/vipconfig/redirect_unix.go
+++ b/vipconfig/redirect_unix.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+package vipconfig
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// redirectStdStreams points the process's stdout (fd 1) and stderr (fd 2) at f
+// at the file-descriptor level. This captures not only writes via os.Stdout /
+// os.Stderr but also anything the Go runtime writes directly to those
+// descriptors (e.g. panic stack traces) and output from child processes that
+// inherit them. It is called again after the log file is reopened on SIGHUP so
+// the redirect follows the freshly created file.
+func redirectStdStreams(f *os.File) error {
+	fd := int(f.Fd())
+	if err := unix.Dup2(fd, int(os.Stdout.Fd())); err != nil {
+		return err
+	}
+	return unix.Dup2(fd, int(os.Stderr.Fd()))
+}

--- a/vipconfig/redirect_windows.go
+++ b/vipconfig/redirect_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+
+package vipconfig
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// redirectStdStreams points the process's standard output and error handles at
+// f. On Windows this updates the process' STD_OUTPUT_HANDLE / STD_ERROR_HANDLE,
+// which is picked up by child processes and by code that resolves the handles
+// at write time. Note that Go's already-initialised os.Stdout / os.Stderr keep
+// their original handles, so this is best-effort; SIGHUP-based log rotation is
+// a Unix concept and Windows is not the primary target for this feature.
+func redirectStdStreams(f *os.File) error {
+	h := windows.Handle(f.Fd())
+	if err := windows.SetStdHandle(windows.STD_OUTPUT_HANDLE, h); err != nil {
+		return err
+	}
+	return windows.SetStdHandle(windows.STD_ERROR_HANDLE, h)
+}

--- a/vipconfig/vip-manager.yml
+++ b/vipconfig/vip-manager.yml
@@ -42,7 +42,8 @@ retry-after: 250  #in milliseconds
 # verbose logs (currently only supported for hetzner)
 verbose: false
 
-# optional path to a log file. when set, logs are written here instead of stdout.
+# optional path to a log file. when set, logs are written here instead of stdout,
+# and the process's stdout/stderr (including panics) are redirected here too.
 # send SIGHUP (e.g. from logrotate's postrotate) to close and reopen the file
 # after it has been rotated. leave unset/empty to log to stdout (systemd journal).
 # log-file: /var/log/vip-manager.log

--- a/vipconfig/vip-manager.yml
+++ b/vipconfig/vip-manager.yml
@@ -41,3 +41,8 @@ retry-after: 250  #in milliseconds
 
 # verbose logs (currently only supported for hetzner)
 verbose: false
+
+# optional path to a log file. when set, logs are written here instead of stdout.
+# send SIGHUP (e.g. from logrotate's postrotate) to close and reopen the file
+# after it has been rotated. leave unset/empty to log to stdout (systemd journal).
+# log-file: /var/log/vip-manager.log


### PR DESCRIPTION
I don't know GO, so this is a vibe-coded attempt at fixing issue #392 .  As it stands I've added this to the service file so we capture output to a file, to match our other existing services:

```
# Log output to a file
StandardOutput=append:/var/log/vip-manager/vip-manager.log
StandardError=append:/var/log/vip-manager/vip-manager.log
```

Possibly you'd prefer us to just use syslog and handle rotation in there?  If that's the case, then we can just close this PR and that Issue.