### PR TITLE
[-] fix stale VIP state after canceled etcd watch, closes #394

### DIFF
--- a/checker/etcd_leader_checker.go
+++ b/checker/etcd_leader_checker.go
@@ -75,56 +75,74 @@ func getTransport(conf *vipconfig.Config) (*tls.Config, error) {
 
 // get gets the current value from etcd
 func (elc *EtcdLeaderChecker) get(ctx context.Context, out chan<- bool) {
-	resp, err := elc.Get(ctx, elc.TriggerKey)
+	// send guards the channel send with ctx to avoid blocking on shutdown
+	send := func(state bool) {
+		select {
+		case out <- state:
+		case <-ctx.Done():
+		}
+	}
+	// Bound the request: the etcd client retries until the context expires,
+	// so without a timeout this would block forever while etcd is unreachable
+	// and never report the failure
+	getCtx, cancel := context.WithTimeout(ctx, time.Duration(max(elc.Interval, 1000))*time.Millisecond)
+	defer cancel()
+	resp, err := elc.Get(getCtx, elc.TriggerKey)
 	if err != nil {
 		elc.Logger.Error("Failed to get value from etcd",
 			zap.String("key", elc.TriggerKey),
 			zap.Error(err))
-		out <- false
+		send(false)
 		return
 	}
 	if resp == nil {
 		elc.Logger.Error("Received nil response from etcd", zap.String("key", elc.TriggerKey))
-		out <- false
+		send(false)
 		return
 	}
 	if len(resp.Kvs) == 0 {
 		elc.Logger.Sugar().Info("No value found for key ", elc.TriggerKey, " - DCS may not have set it yet")
-		out <- false
+		send(false)
 		return
 	}
 	for _, kv := range resp.Kvs {
 		value := string(kv.Value)
 		matches := value == elc.TriggerValue
 		elc.Logger.Sugar().Info("Current value from DCS:", value)
-		out <- matches
+		send(matches)
 	}
 }
 
 // watch monitors value changes from etcd
 func (elc *EtcdLeaderChecker) watch(ctx context.Context, out chan<- bool) error {
 	elc.Logger.Sugar().Info("Setting WATCH on ", elc.TriggerKey)
-	watchChan := elc.Watch(ctx, elc.TriggerKey)
+	// WithRequireLeader makes the watch fail fast when the etcd server
+	// loses its quorum instead of silently returning no events
+	watchCtx := clientv3.WithRequireLeader(ctx)
+	watchChan := elc.Watch(watchCtx, elc.TriggerKey)
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case watchResp := <-watchChan:
-			if watchResp.Canceled {
-				watchChan = elc.Watch(ctx, elc.TriggerKey)
-				elc.Logger.Sugar().Info("Resetting cancelled WATCH on ", elc.TriggerKey)
-				continue
-			}
-			if err := watchResp.Err(); err != nil {
-				elc.Logger.Error("Watch error", zap.String("key", elc.TriggerKey), zap.Error(err))
-				// Signal false on watch error so VIP is removed if connection is lost
-				// Guard the send with ctx to avoid deadlock during shutdown
+		case watchResp, ok := <-watchChan:
+			if !ok || watchResp.Canceled || watchResp.Err() != nil {
+				// The watch is dead. Any events that occurred while
+				// the watch was down may have been lost, so after re-arming
+				// the watch we re-fetch the current value via get()
+				elc.Logger.Error("WATCH on key lost, re-establishing and re-syncing state",
+					zap.String("key", elc.TriggerKey),
+					zap.Error(watchResp.Err()))
+				// Back off briefly to avoid a busy loop when etcd is unreachable
 				select {
-				case out <- false:
+				case <-time.After(time.Second):
 				case <-ctx.Done():
 					return ctx.Err()
 				}
-				watchChan = elc.Watch(ctx, elc.TriggerKey)
+				watchChan = elc.Watch(watchCtx, elc.TriggerKey)
+				elc.Logger.Sugar().Info("Resetting cancelled WATCH on ", elc.TriggerKey)
+				// Re-fetch the current value: events may have been missed
+				// while the watch was down (e.g. a leader change)
+				elc.get(ctx, out)
 				continue
 			}
 			for _, event := range watchResp.Events {

--- a/checker/etcd_leader_checker_test.go
+++ b/checker/etcd_leader_checker_test.go
@@ -447,3 +447,60 @@ func TestEtcdLeaderChecker_GetChangeNotificationStream_EmitsOnConnectionError(t 
 		t.Error("expected false to be emitted when etcd is unreachable, but no false value was received")
 	}
 }
+
+// TestEtcdLeaderChecker_watch_ResyncsOnCanceledWatch is a regression test
+// for https://github.com/cybertec-postgresql/vip-manager/issues/394: when the
+// watch channel dies (canceled by the server or closed) and the leader
+// changes while the watch is down, the checker must re-sync the state via
+// get() instead of silently re-arming the watch and keeping stale state.
+func TestEtcdLeaderChecker_watch_ResyncsOnCanceledWatch(t *testing.T) {
+	endpoints, seed := startEtcdContainer(t)
+	checker := newIntegrationChecker(t, endpoints, "/leader", "primary")
+
+	// Make this node the leader so a stale state would keep the VIP up.
+	if _, err := seed.Put(context.Background(), "/leader", "primary"); err != nil {
+		t.Fatalf("seed Put: %v", err)
+	}
+
+	out := make(chan bool, 10)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	watchDone := make(chan error, 1)
+	go func() { watchDone <- checker.watch(ctx, out) }()
+
+	// Allow the watch to register on the server.
+	time.Sleep(150 * time.Millisecond)
+
+	// Kill all watch streams: closing the client's Watcher closes the watch
+	// channel, simulating a server-side cancellation / dead watch.
+	if err := checker.Watcher.Close(); err != nil {
+		t.Fatalf("Watcher.Close: %v", err)
+	}
+
+	// While the watch is dead, the leader changes to another node. The old
+	// code lost this event forever; the fix re-fetches the value via get().
+	if _, err := seed.Put(context.Background(), "/leader", "secondary"); err != nil {
+		t.Fatalf("Put leader change: %v", err)
+	}
+
+	// The re-sync must emit false because this node is no longer the leader.
+	select {
+	case got := <-out:
+		if got {
+			t.Error("expected false after leader change during dead watch, got true")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for re-synced state after watch channel died")
+	}
+
+	cancel()
+	select {
+	case err := <-watchDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected context.Canceled from watch, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for watch goroutine to exit")
+	}
+}


### PR DESCRIPTION
### Problem

When an etcd watch was canceled (e.g., due to a transient network issue), `EtcdLeaderChecker.watch()` simply re-armed the watch and continued. This had two flaws:

1. **Lost events**: any leader-change events that occurred while the watch was down were lost forever. The node kept its last known state — in #394, the old leader kept the VIP up for a week while the new leader also brought it up, resulting in the VIP being active on **two nodes** simultaneously.
2. **Undetected dead channel**: a *closed* watch channel was never detected. Receiving from a closed channel returns a zero-value `WatchResponse` instantly with `Canceled == false` and `Err() == nil`, so the loop spun silently without ever recovering.

### Fix

In `checker/etcd_leader_checker.go`:

- **Detect all dead-watch conditions**: treat a closed channel (`!ok`), `watchResp.Canceled`, and `watchResp.Err() != nil` uniformly as "watch is dead".
- **Re-sync state after recovery**: after re-establishing the watch, call `get()` to fetch the current leader from etcd, recovering any events missed while the watch was down. This is the actual fix for #394.
- **No VIP flapping on transient glitches**: we deliberately do *not* signal `false` when the watch dies — bouncing the VIP (gratuitous ARP, network-wide reaction) on a short glitch would be more disruptive than a 1–2 s window of stale state. If the node is still the leader, `get()` confirms it and the VIP never moves.
- **Back off 1 s** between reconnect attempts to avoid a busy loop while etcd is unreachable.
- **`clientv3.WithRequireLeader`** on the watch context, so the watch fails fast when the etcd server loses quorum instead of silently delivering no events.
- **Bound `get()` with a timeout** (`max(interval, 1000)` ms): the etcd client retries a `Get` until the context expires, so an unbounded call would block forever during a real etcd outage and never report the failure. With the timeout, a prolonged outage still results in `false` (VIP released), preserving the existing DCS-unreachable behavior.
- **Guard all channel sends with `ctx.Done()`** to avoid a shutdown deadlock, since `get()` is now also called synchronously from the watch loop and `main.go` uses an unbuffered channel.

### Testing

- New regression test `TestEtcdLeaderChecker_watch_ResyncsOnCanceledWatch`: makes the node the leader, kills the watcher (simulating a server-side cancellation), changes the leader *while the watch is dead*, and asserts the checker re-syncs and emits `false`. Times out on the old code; passes with the fix.
- Full `./checker` suite passes (testcontainers-based etcd integration tests included), notably `TestEtcdLeaderChecker_GetChangeNotificationStream_EmitsOnConnectionError`, which verifies `false` is still emitted when etcd is completely unreachable.

### Behavior summary

| Scenario | Before | After |
|---|---|---|
| Transient watch cancellation, still leader | Stale state, no re-sync (VIP could stay up incorrectly forever) | `get()` re-sync confirms leadership, no VIP flap |
| Leader changed while watch was down | Event lost — **VIP up on two nodes** | `get()` re-sync detects change, VIP released |
| Watch channel closed | Busy loop, never recovered | Detected, watch re-armed + re-sync |
| Prolonged etcd outage | `get()` blocked indefinitely | Bounded by timeout, emits `false`, VIP released |