### PR TITLE
[+] send unsolicited IPv6 Neighbor Advertisements for IPv6

### DIFF
--- a/ipmanager/basicConfigurer.go
+++ b/ipmanager/basicConfigurer.go
@@ -25,7 +25,7 @@ func newBasicConfigurer(config *IPConfiguration) (*BasicConfigurer, error) {
 	if c.Iface.HardwareAddr == nil || c.Iface.HardwareAddr.String() == "00:00:00:00:00:00" {
 		return nil, errors.New(`cannot run vip-manager on the loopback device
 as its hardware address is the local address (00:00:00:00:00:00),
-which prohibits sending of gratuitous ARP messages`)
+which prohibits sending of gratuitous ARP messages and IPv6 Neighbor Advertisements`)
 	}
 	return c, nil
 }
@@ -53,7 +53,8 @@ const (
 	IPv4AddressSize = 4
 )
 
-// serializePacketLayers serializes packet layers (mockable for testing).
+// serializePacketLayers is gopacket.SerializeLayers, kept in a variable so
+// tests can force a serialization failure.
 var serializePacketLayers = gopacket.SerializeLayers
 
 // createGratuitousNA prepares an unsolicited IPv6 Neighbor Advertisement.
@@ -102,6 +103,9 @@ func (c *BasicConfigurer) createGratuitousNA(sourceIP net.IP) ([]byte, error) {
 
 // createGratuitousARP prepares a packet with a gratuitous ARP request
 func (c *BasicConfigurer) createGratuitousARP() ([]byte, error) {
+	// Unmap so that a ::ffff:a.b.c.d VIP yields the 4 bytes ProtAddressSize promises.
+	vip := c.VIP.Unmap().AsSlice()
+
 	// Create the Ethernet layer
 	ethLayer := &layers.Ethernet{
 		SrcMAC:       c.Iface.HardwareAddr,
@@ -117,9 +121,9 @@ func (c *BasicConfigurer) createGratuitousARP() ([]byte, error) {
 		ProtAddressSize:   IPv4AddressSize,
 		Operation:         layers.ARPReply, // Gratuitous ARP is sent as a reply
 		SourceHwAddress:   c.Iface.HardwareAddr,
-		SourceProtAddress: c.VIP.AsSlice(),
+		SourceProtAddress: vip,
 		DstHwAddress:      c.Iface.HardwareAddr, // Gratuitous ARP targets itself
-		DstProtAddress:    c.VIP.AsSlice(),
+		DstProtAddress:    vip,
 	}
 
 	// Create a packet with the layers

--- a/ipmanager/basicConfigurer.go
+++ b/ipmanager/basicConfigurer.go
@@ -53,6 +53,9 @@ const (
 	IPv4AddressSize = 4
 )
 
+// serializePacketLayers serializes packet layers (mockable for testing).
+var serializePacketLayers = gopacket.SerializeLayers
+
 // createGratuitousNA prepares an unsolicited IPv6 Neighbor Advertisement.
 func (c *BasicConfigurer) createGratuitousNA(sourceIP net.IP) ([]byte, error) {
 	allNodes := net.ParseIP("ff02::1")
@@ -90,7 +93,7 @@ func (c *BasicConfigurer) createGratuitousNA(sourceIP net.IP) ([]byte, error) {
 		FixLengths:       true,
 		ComputeChecksums: true,
 	}
-	if err := gopacket.SerializeLayers(buffer, opts, ethLayer, ipv6Layer, icmpLayer, naLayer); err != nil {
+	if err := serializePacketLayers(buffer, opts, ethLayer, ipv6Layer, icmpLayer, naLayer); err != nil {
 		return nil, err
 	}
 
@@ -126,7 +129,7 @@ func (c *BasicConfigurer) createGratuitousARP() ([]byte, error) {
 		ComputeChecksums: true,
 	}
 
-	if err := gopacket.SerializeLayers(buffer, opts, ethLayer, arpLayer); err != nil {
+	if err := serializePacketLayers(buffer, opts, ethLayer, arpLayer); err != nil {
 		return nil, err
 	}
 

--- a/ipmanager/basicConfigurer.go
+++ b/ipmanager/basicConfigurer.go
@@ -53,6 +53,50 @@ const (
 	IPv4AddressSize = 4
 )
 
+// createGratuitousNA prepares an unsolicited IPv6 Neighbor Advertisement.
+func (c *BasicConfigurer) createGratuitousNA(sourceIP net.IP) ([]byte, error) {
+	allNodes := net.ParseIP("ff02::1")
+	ethLayer := &layers.Ethernet{
+		SrcMAC:       c.Iface.HardwareAddr,
+		DstMAC:       net.HardwareAddr{0x33, 0x33, 0x00, 0x00, 0x00, 0x01},
+		EthernetType: layers.EthernetTypeIPv6,
+	}
+	ipv6Layer := &layers.IPv6{
+		Version:    6,
+		NextHeader: layers.IPProtocolICMPv6,
+		HopLimit:   255,
+		SrcIP:      sourceIP,
+		DstIP:      allNodes,
+	}
+	naLayer := &layers.ICMPv6NeighborAdvertisement{
+		Flags:         0x20, // Override existing neighbor cache entries.
+		TargetAddress: c.VIP.AsSlice(),
+		Options: layers.ICMPv6Options{
+			{
+				Type: layers.ICMPv6OptTargetAddress,
+				Data: c.Iface.HardwareAddr,
+			},
+		},
+	}
+	icmpLayer := &layers.ICMPv6{
+		TypeCode: layers.CreateICMPv6TypeCode(layers.ICMPv6TypeNeighborAdvertisement, 0),
+	}
+	if err := icmpLayer.SetNetworkLayerForChecksum(ipv6Layer); err != nil {
+		return nil, err
+	}
+
+	buffer := gopacket.NewSerializeBuffer()
+	opts := gopacket.SerializeOptions{
+		FixLengths:       true,
+		ComputeChecksums: true,
+	}
+	if err := gopacket.SerializeLayers(buffer, opts, ethLayer, ipv6Layer, icmpLayer, naLayer); err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}
+
 // createGratuitousARP prepares a packet with a gratuitous ARP request
 func (c *BasicConfigurer) createGratuitousARP() ([]byte, error) {
 	// Create the Ethernet layer

--- a/ipmanager/basicConfigurer.go
+++ b/ipmanager/basicConfigurer.go
@@ -13,7 +13,7 @@ import (
 // that handle their own network connection, in setups where it is
 // sufficient to add the virtual ip using `ip addr add ...` .
 // After adding the virtual ip to the specified interface,
-// a gratuitous ARP package is sent out to update the tables of
+// a gratuitous ARP package or IPv6 Neighbor Advertisement is sent out to update the tables of
 // nearby routers and other devices.
 type BasicConfigurer struct {
 	*IPConfiguration

--- a/ipmanager/basicConfigurer_linux.go
+++ b/ipmanager/basicConfigurer_linux.go
@@ -1,6 +1,7 @@
 package ipmanager
 
 import (
+	"fmt"
 	"net"
 	"os/exec"
 	"syscall"
@@ -12,6 +13,10 @@ func htons(i uint16) uint16 {
 }
 
 func sendPacketLinux(iface net.Interface, packetData []byte) error {
+	return sendPacketLinuxWithProtocol(iface, packetData, syscall.ETH_P_ARP)
+}
+
+func sendPacketLinuxWithProtocol(iface net.Interface, packetData []byte, protocol uint16) error {
 	fd, err := syscall.Socket(syscall.AF_PACKET, syscall.SOCK_RAW, int(htons(syscall.ETH_P_ALL)))
 	if err != nil {
 		return err
@@ -19,10 +24,10 @@ func sendPacketLinux(iface net.Interface, packetData []byte) error {
 	defer syscall.Close(fd)
 
 	var sll syscall.SockaddrLinklayer
-	sll.Protocol = htons(syscall.ETH_P_ARP)
+	sll.Protocol = htons(protocol)
 	sll.Ifindex = iface.Index
 	sll.Hatype = syscall.ARPHRD_ETHER
-	sll.Pkttype = syscall.PACKET_BROADCAST
+	sll.Pkttype = syscall.PACKET_HOST
 
 	if err = syscall.Bind(fd, &sll); err != nil {
 		return err
@@ -31,15 +36,51 @@ func sendPacketLinux(iface net.Interface, packetData []byte) error {
 	return syscall.Sendto(fd, packetData, 0, &sll)
 }
 
+func (c *BasicConfigurer) linkLocalAddress() (net.IP, error) {
+	iface, err := net.InterfaceByName(c.Iface.Name)
+	if err != nil {
+		return nil, err
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, err
+	}
+	for _, addr := range addrs {
+		var ip net.IP
+		switch value := addr.(type) {
+		case *net.IPNet:
+			ip = value.IP
+		case *net.IPAddr:
+			ip = value.IP
+		}
+		if ip != nil && ip.To4() == nil && ip.IsLinkLocalUnicast() {
+			return ip, nil
+		}
+	}
+	return nil, fmt.Errorf("interface %s has no IPv6 link-local address", c.Iface.Name)
+}
+
 // configureAddress assigns virtual IP address
 func (c *BasicConfigurer) configureAddress() bool {
 	log.Infof("Configuring address %s on %s", c.getCIDR(), c.Iface.Name)
 	result := c.runAddressConfiguration("add")
 	if result {
-		if buff, err := c.createGratuitousARP(); err != nil {
-			log.Warn("Failed to compose gratuitous ARP request: ", err)
+		if c.VIP.Is6() {
+			sourceIP, err := c.linkLocalAddress()
+			if err != nil {
+				log.Warn("Failed to find IPv6 link-local address for Neighbor Advertisement: ", err)
+				return result
+			}
+			buff, err := c.createGratuitousNA(sourceIP)
+			if err != nil {
+				log.Warn("Failed to compose unsolicited Neighbor Advertisement: ", err)
+			} else if err := sendPacketLinuxWithProtocol(c.Iface, buff, syscall.ETH_P_IPV6); err != nil {
+				log.Warn("Failed to send unsolicited Neighbor Advertisement: ", err)
+			}
 		} else {
-			if err := sendPacketLinux(c.Iface, buff); err != nil {
+			if buff, err := c.createGratuitousARP(); err != nil {
+				log.Warn("Failed to compose gratuitous ARP request: ", err)
+			} else if err := sendPacketLinux(c.Iface, buff); err != nil {
 				log.Warn("Failed to send gratuitous ARP request: ", err)
 			}
 		}

--- a/ipmanager/basicConfigurer_linux.go
+++ b/ipmanager/basicConfigurer_linux.go
@@ -7,6 +7,9 @@ import (
 	"syscall"
 )
 
+var execCommand = exec.Command
+var linuxSendPacketWithProtocolFn = sendPacketLinuxWithProtocol
+
 // htons converts uint16 to network byte order
 func htons(i uint16) uint16 {
 	return (i<<8)&0xff00 | i>>8
@@ -74,7 +77,7 @@ func (c *BasicConfigurer) configureAddress() bool {
 			buff, err := c.createGratuitousNA(sourceIP)
 			if err != nil {
 				log.Warn("Failed to compose unsolicited Neighbor Advertisement: ", err)
-			} else if err := sendPacketLinuxWithProtocol(c.Iface, buff, syscall.ETH_P_IPV6); err != nil {
+			} else if err := linuxSendPacketWithProtocolFn(c.Iface, buff, syscall.ETH_P_IPV6); err != nil {
 				log.Warn("Failed to send unsolicited Neighbor Advertisement: ", err)
 			}
 		} else {
@@ -96,7 +99,7 @@ func (c *BasicConfigurer) deconfigureAddress() bool {
 }
 
 func (c *BasicConfigurer) runAddressConfiguration(action string) bool {
-	cmd := exec.Command("ip", "addr", action,
+	cmd := execCommand("ip", "addr", action,
 		c.getCIDR(),
 		"dev", c.Iface.Name)
 	output, err := cmd.CombinedOutput()

--- a/ipmanager/basicConfigurer_linux.go
+++ b/ipmanager/basicConfigurer_linux.go
@@ -9,6 +9,18 @@ import (
 
 var execCommand = exec.Command
 var linuxSendPacketWithProtocolFn = sendPacketLinuxWithProtocol
+var interfaceAddrsFn = defaultInterfaceAddrs
+
+// defaultInterfaceAddrs returns the addresses currently assigned to the named
+// interface. It is kept in a variable so tests can drive the IPv6 branch of
+// configureAddress on hosts that have no suitable interface.
+func defaultInterfaceAddrs(name string) ([]net.Addr, error) {
+	iface, err := net.InterfaceByName(name)
+	if err != nil {
+		return nil, err
+	}
+	return iface.Addrs()
+}
 
 // htons converts uint16 to network byte order
 func htons(i uint16) uint16 {
@@ -30,7 +42,7 @@ func sendPacketLinuxWithProtocol(iface net.Interface, packetData []byte, protoco
 	sll.Protocol = htons(protocol)
 	sll.Ifindex = iface.Index
 	sll.Hatype = syscall.ARPHRD_ETHER
-	sll.Pkttype = syscall.PACKET_HOST
+	sll.Pkttype = syscall.PACKET_BROADCAST
 
 	if err = syscall.Bind(fd, &sll); err != nil {
 		return err
@@ -39,15 +51,8 @@ func sendPacketLinuxWithProtocol(iface net.Interface, packetData []byte, protoco
 	return syscall.Sendto(fd, packetData, 0, &sll)
 }
 
-func (c *BasicConfigurer) linkLocalAddress() (net.IP, error) {
-	iface, err := net.InterfaceByName(c.Iface.Name)
-	if err != nil {
-		return nil, err
-	}
-	addrs, err := iface.Addrs()
-	if err != nil {
-		return nil, err
-	}
+// pickLinkLocal returns the first IPv6 link-local unicast address found in addrs.
+func pickLinkLocal(ifaceName string, addrs []net.Addr) (net.IP, error) {
 	for _, addr := range addrs {
 		var ip net.IP
 		switch value := addr.(type) {
@@ -60,36 +65,67 @@ func (c *BasicConfigurer) linkLocalAddress() (net.IP, error) {
 			return ip, nil
 		}
 	}
-	return nil, fmt.Errorf("interface %s has no IPv6 link-local address", c.Iface.Name)
+	return nil, fmt.Errorf("interface %s has no IPv6 link-local address", ifaceName)
+}
+
+// linkLocalAddress returns the interface's IPv6 link-local address, which is
+// used as the source of the unsolicited Neighbor Advertisement. The VIP itself
+// cannot be used: right after `ip addr add` it is still tentative while
+// Duplicate Address Detection runs, and RFC 4862 forbids sending from a
+// tentative address.
+func (c *BasicConfigurer) linkLocalAddress() (net.IP, error) {
+	addrs, err := interfaceAddrsFn(c.Iface.Name)
+	if err != nil {
+		return nil, err
+	}
+	return pickLinkLocal(c.Iface.Name, addrs)
+}
+
+// sendNeighborAdvertisement announces the new owner of an IPv6 VIP to all nodes
+// on the link, so neighbours replace their cached MAC address immediately
+// instead of waiting for the neighbor cache entry to expire.
+func (c *BasicConfigurer) sendNeighborAdvertisement() {
+	sourceIP, err := c.linkLocalAddress()
+	if err != nil {
+		log.Warn("Failed to find IPv6 link-local address for Neighbor Advertisement: ", err)
+		return
+	}
+	buff, err := c.createGratuitousNA(sourceIP)
+	if err != nil {
+		log.Warn("Failed to compose unsolicited Neighbor Advertisement: ", err)
+		return
+	}
+	if err := linuxSendPacketWithProtocolFn(c.Iface, buff, syscall.ETH_P_IPV6); err != nil {
+		log.Warn("Failed to send unsolicited Neighbor Advertisement: ", err)
+	}
+}
+
+// sendGratuitousARP announces the new owner of an IPv4 VIP on the link.
+func (c *BasicConfigurer) sendGratuitousARP() {
+	buff, err := c.createGratuitousARP()
+	if err != nil {
+		log.Warn("Failed to compose gratuitous ARP request: ", err)
+		return
+	}
+	if err := linuxSendPacketWithProtocolFn(c.Iface, buff, syscall.ETH_P_ARP); err != nil {
+		log.Warn("Failed to send gratuitous ARP request: ", err)
+	}
 }
 
 // configureAddress assigns virtual IP address
 func (c *BasicConfigurer) configureAddress() bool {
 	log.Infof("Configuring address %s on %s", c.getCIDR(), c.Iface.Name)
-	result := c.runAddressConfiguration("add")
-	if result {
-		if c.VIP.Is6() {
-			sourceIP, err := c.linkLocalAddress()
-			if err != nil {
-				log.Warn("Failed to find IPv6 link-local address for Neighbor Advertisement: ", err)
-				return result
-			}
-			buff, err := c.createGratuitousNA(sourceIP)
-			if err != nil {
-				log.Warn("Failed to compose unsolicited Neighbor Advertisement: ", err)
-			} else if err := linuxSendPacketWithProtocolFn(c.Iface, buff, syscall.ETH_P_IPV6); err != nil {
-				log.Warn("Failed to send unsolicited Neighbor Advertisement: ", err)
-			}
-		} else {
-			if buff, err := c.createGratuitousARP(); err != nil {
-				log.Warn("Failed to compose gratuitous ARP request: ", err)
-			} else if err := sendPacketLinux(c.Iface, buff); err != nil {
-				log.Warn("Failed to send gratuitous ARP request: ", err)
-			}
-		}
+	if !c.runAddressConfiguration("add") {
+		return false
 	}
-
-	return result
+	// Is6 alone is not enough: it is also true for IPv4-in-IPv6 addresses such
+	// as ::ffff:192.0.2.1, which belong on the ARP path.
+	if c.VIP.Is6() && !c.VIP.Is4In6() {
+		c.sendNeighborAdvertisement()
+	} else {
+		c.sendGratuitousARP()
+	}
+	return true
 }
 
 // deconfigureAddress drops virtual IP address

--- a/ipmanager/basicConfigurer_linux_test.go
+++ b/ipmanager/basicConfigurer_linux_test.go
@@ -298,7 +298,7 @@ func TestBasicConfigurer_configureAddress_IPv6(t *testing.T) {
 			name:     "success",
 			iface:    net.Interface{Name: "lo"},
 			wantSend: true,
-			sendCheck: func(iface net.Interface, packetData []byte, protocol uint16) error {
+			sendCheck: func(_ net.Interface, _ []byte, protocol uint16) error {
 				if protocol != syscall.ETH_P_IPV6 {
 					t.Fatalf("wrong protocol: got %d want %d", protocol, syscall.ETH_P_IPV6)
 				}
@@ -309,7 +309,7 @@ func TestBasicConfigurer_configureAddress_IPv6(t *testing.T) {
 			name:     "no-link-local",
 			iface:    net.Interface{Name: "loopback-test"},
 			wantSend: false,
-			sendCheck: func(iface net.Interface, packetData []byte, protocol uint16) error {
+			sendCheck: func(_ net.Interface, _ []byte, _ uint16) error {
 				t.Fatal("send should not be called when no IPv6 link-local address is available")
 				return nil
 			},
@@ -319,7 +319,7 @@ func TestBasicConfigurer_configureAddress_IPv6(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mockLogger(t)
-			mockExecCommand(t, func(name string, args ...string) *exec.Cmd { return exec.Command("true") })
+			mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd { return exec.Command("true") })
 			mockIPv6Send(t, tt.sendCheck)
 
 			c := &BasicConfigurer{
@@ -339,7 +339,7 @@ func TestBasicConfigurer_configureAddress_IPv6(t *testing.T) {
 
 func TestBasicConfigurer_runAddressConfiguration_ErrorExit(t *testing.T) {
 	mockLogger(t)
-	mockExecCommand(t, func(name string, args ...string) *exec.Cmd {
+	mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd {
 		return exec.Command("sh", "-c", "exit 1")
 	})
 

--- a/ipmanager/basicConfigurer_linux_test.go
+++ b/ipmanager/basicConfigurer_linux_test.go
@@ -3,6 +3,8 @@
 package ipmanager
 
 import (
+	"bytes"
+	"errors"
 	"net"
 	"net/netip"
 	"os"
@@ -10,6 +12,8 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/google/gopacket"
+	"github.com/google/gopacket/layers"
 	"go.uber.org/zap"
 )
 
@@ -337,6 +341,193 @@ func TestBasicConfigurer_configureAddress_IPv6(t *testing.T) {
 	}
 }
 
+// TestBasicConfigurer_configureAddress_IPv6_RunAddrConfigFails verifies that
+// when runAddressConfiguration fails for an IPv6 VIP, configureAddress returns
+// false and never attempts to send a Neighbor Advertisement.
+func TestBasicConfigurer_configureAddress_IPv6_RunAddrConfigFails(t *testing.T) {
+	t.Parallel()
+	mockLogger(t)
+	mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd {
+		return exec.Command("sh", "-c", "exit 1")
+	})
+
+	sendCalled := false
+	mockIPv6Send(t, func(_ net.Interface, _ []byte, _ uint16) error {
+		sendCalled = true
+		t.Fatal("send should not be called when runAddressConfiguration fails")
+		return nil
+	})
+
+	c := &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			VIP:     netip.MustParseAddr("2001:db8::10"),
+			Netmask: net.CIDRMask(64, 128),
+			Iface:   net.Interface{Name: "lo"},
+		},
+	}
+
+	if got := c.configureAddress(); got {
+		t.Fatal("configureAddress() = true, want false when runAddressConfiguration fails")
+	}
+	if sendCalled {
+		t.Error("NA send was called despite runAddressConfiguration failure")
+	}
+}
+
+// TestBasicConfigurer_configureAddress_IPv6_SendNAFails verifies that
+// when the NA packet send fails, configureAddress still returns true
+// (the address was successfully added) and handles the error gracefully.
+func TestBasicConfigurer_configureAddress_IPv6_SendNAFails(t *testing.T) {
+	t.Parallel()
+	mockLogger(t)
+	mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd { return exec.Command("true") })
+
+	sendErr := errors.New("mock send error: permission denied")
+	mockIPv6Send(t, func(_ net.Interface, _ []byte, protocol uint16) error {
+		if protocol != syscall.ETH_P_IPV6 {
+			t.Fatalf("wrong protocol: got %d want %d", protocol, syscall.ETH_P_IPV6)
+		}
+		return sendErr
+	})
+
+	c := &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			VIP:     netip.MustParseAddr("2001:db8::10"),
+			Netmask: net.CIDRMask(64, 128),
+			Iface:   net.Interface{Name: "lo"},
+		},
+	}
+
+	// configureAddress should still return true because the address was added
+	// successfully; the NA send failure only produces a warning log.
+	if got := c.configureAddress(); !got {
+		t.Fatal("configureAddress() = false, want true even when NA send fails")
+	}
+}
+
+func validateIPv6NAEthernetLayer(t *testing.T, packet []byte, hwAddr net.HardwareAddr) {
+	t.Helper()
+	parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
+	ethLayer := parsed.Layer(layers.LayerTypeEthernet)
+	if ethLayer == nil {
+		t.Fatal("missing Ethernet layer")
+	}
+	eth := ethLayer.(*layers.Ethernet)
+	wantMulticastMAC := net.HardwareAddr{0x33, 0x33, 0x00, 0x00, 0x00, 0x01}
+	if !bytes.Equal(eth.DstMAC, wantMulticastMAC) {
+		t.Errorf("Ethernet DstMAC = %v, want all-nodes multicast %v", eth.DstMAC, wantMulticastMAC)
+	}
+	if !bytes.Equal(eth.SrcMAC, hwAddr) {
+		t.Errorf("Ethernet SrcMAC = %v, want %v", eth.SrcMAC, hwAddr)
+	}
+	if eth.EthernetType != layers.EthernetTypeIPv6 {
+		t.Errorf("Ethernet EthernetType = %v, want IPv6", eth.EthernetType)
+	}
+}
+
+func validateIPv6NAIPv6Layer(t *testing.T, packet []byte) {
+	t.Helper()
+	parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
+	ipv6Layer := parsed.Layer(layers.LayerTypeIPv6)
+	if ipv6Layer == nil {
+		t.Fatal("missing IPv6 layer")
+	}
+	ipv6 := ipv6Layer.(*layers.IPv6)
+	if ipv6.Version != 6 {
+		t.Errorf("IPv6 Version = %d, want 6", ipv6.Version)
+	}
+	if ipv6.HopLimit != 255 {
+		t.Errorf("IPv6 HopLimit = %d, want 255", ipv6.HopLimit)
+	}
+	if ipv6.NextHeader != layers.IPProtocolICMPv6 {
+		t.Errorf("IPv6 NextHeader = %v, want ICMPv6", ipv6.NextHeader)
+	}
+	allNodes := net.ParseIP("ff02::1")
+	if !ipv6.DstIP.Equal(allNodes) {
+		t.Errorf("IPv6 DstIP = %s, want %s", ipv6.DstIP, allNodes)
+	}
+	if ipv6.SrcIP == nil || !ipv6.SrcIP.IsLinkLocalUnicast() {
+		t.Errorf("IPv6 SrcIP = %s, want a link-local address", ipv6.SrcIP)
+	}
+}
+
+func validateIPv6NAICMPv6Layer(t *testing.T, packet []byte) {
+	t.Helper()
+	parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
+	icmpLayer := parsed.Layer(layers.LayerTypeICMPv6)
+	if icmpLayer == nil {
+		t.Fatal("missing ICMPv6 layer")
+	}
+	icmp := icmpLayer.(*layers.ICMPv6)
+	if icmp.TypeCode.Type() != layers.ICMPv6TypeNeighborAdvertisement {
+		t.Errorf("ICMPv6 Type = %v, want NA (%d)", icmp.TypeCode.Type(), layers.ICMPv6TypeNeighborAdvertisement)
+	}
+}
+
+func validateIPv6NANeighborAdvertisementLayer(t *testing.T, packet []byte, vipAddr netip.Addr, hwAddr net.HardwareAddr) {
+	t.Helper()
+	parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
+	naLayer := parsed.Layer(layers.LayerTypeICMPv6NeighborAdvertisement)
+	if naLayer == nil {
+		t.Fatal("missing ICMPv6NeighborAdvertisement layer")
+	}
+	na := naLayer.(*layers.ICMPv6NeighborAdvertisement)
+	if na.Flags&0x20 == 0 {
+		t.Errorf("NA Override flag not set, flags = 0x%x", na.Flags)
+	}
+	wantVIP := vipAddr.AsSlice()
+	if !net.IP(na.TargetAddress).Equal(net.IP(wantVIP)) {
+		t.Errorf("NA TargetAddress = %s, want %s", na.TargetAddress, vipAddr)
+	}
+	if len(na.Options) != 1 {
+		t.Fatalf("NA Options length = %d, want 1", len(na.Options))
+	}
+	if na.Options[0].Type != layers.ICMPv6OptTargetAddress {
+		t.Errorf("NA Option Type = %v, want TargetLinkLayerAddress", na.Options[0].Type)
+	}
+	if !bytes.Equal(na.Options[0].Data, hwAddr) {
+		t.Errorf("NA Option Data = %v, want MAC %v", na.Options[0].Data, hwAddr)
+	}
+}
+
+// TestBasicConfigurer_configureAddress_IPv6_NAPacketContent validates the
+// full content of the unsolicited Neighbor Advertisement packet that is sent
+// after a new IPv6 address is bound to the interface.
+func TestBasicConfigurer_configureAddress_IPv6_NAPacketContent(t *testing.T) {
+	t.Parallel()
+	mockLogger(t)
+	mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd { return exec.Command("true") })
+
+	vipAddr := netip.MustParseAddr("2001:db8::10")
+	hwAddr := net.HardwareAddr{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
+
+	mockIPv6Send(t, func(_ net.Interface, packet []byte, protocol uint16) error {
+		if protocol != syscall.ETH_P_IPV6 {
+			t.Fatalf("protocol = %d, want ETH_P_IPV6 (%d)", protocol, syscall.ETH_P_IPV6)
+		}
+		validateIPv6NAEthernetLayer(t, packet, hwAddr)
+		validateIPv6NAIPv6Layer(t, packet)
+		validateIPv6NAICMPv6Layer(t, packet)
+		validateIPv6NANeighborAdvertisementLayer(t, packet, vipAddr, hwAddr)
+		return nil
+	})
+
+	c := &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			VIP:     vipAddr,
+			Netmask: net.CIDRMask(64, 128),
+			Iface: net.Interface{
+				Name:         "lo",
+				HardwareAddr: hwAddr,
+			},
+		},
+	}
+
+	if got := c.configureAddress(); !got {
+		t.Fatal("configureAddress() = false, want true")
+	}
+}
+
 func TestBasicConfigurer_runAddressConfiguration_ErrorExit(t *testing.T) {
 	mockLogger(t)
 	mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd {
@@ -353,6 +544,92 @@ func TestBasicConfigurer_runAddressConfiguration_ErrorExit(t *testing.T) {
 
 	if c.runAddressConfiguration("add") {
 		t.Fatal("runAddressConfiguration() = true, want false")
+	}
+}
+
+// TestBasicConfigurer_configureAddress_IPv4_MockedSend verifies the IPv4 branch
+// of configureAddress: after a successful address add, a gratuitous ARP is
+// composed and sent on the interface.
+func TestBasicConfigurer_configureAddress_IPv4_MockedSend(t *testing.T) {
+	t.Parallel()
+	mockLogger(t)
+	mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd { return exec.Command("true") })
+
+	vipAddr := netip.MustParseAddr("192.168.1.100")
+	hwAddr := net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
+
+	old := linuxSendPacketWithProtocolFn
+	linuxSendPacketWithProtocolFn = func(_ net.Interface, packet []byte, protocol uint16) error {
+		if protocol != syscall.ETH_P_ARP {
+			t.Errorf("protocol = %d, want ETH_P_ARP (%d)", protocol, syscall.ETH_P_ARP)
+		}
+		parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
+		ethLayer := parsed.Layer(layers.LayerTypeEthernet)
+		if ethLayer == nil {
+			t.Fatal("missing Ethernet layer in ARP packet")
+		}
+		eth := ethLayer.(*layers.Ethernet)
+		if eth.EthernetType != layers.EthernetTypeARP {
+			t.Errorf("Ethernet type = %v, want ARP", eth.EthernetType)
+		}
+		arpLayer := parsed.Layer(layers.LayerTypeARP)
+		if arpLayer == nil {
+			t.Fatal("missing ARP layer")
+		}
+		arp := arpLayer.(*layers.ARP)
+		if !bytes.Equal(arp.SourceProtAddress, vipAddr.AsSlice()) {
+			t.Errorf("ARP SourceProtAddress = %v, want %v", arp.SourceProtAddress, vipAddr.AsSlice())
+		}
+		if !bytes.Equal(arp.SourceHwAddress, hwAddr) {
+			t.Errorf("ARP SourceHwAddress = %v, want %v", arp.SourceHwAddress, hwAddr)
+		}
+		return nil
+	}
+	t.Cleanup(func() { linuxSendPacketWithProtocolFn = old })
+
+	c := &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			VIP:     vipAddr,
+			Netmask: net.CIDRMask(24, 32),
+			Iface: net.Interface{
+				Name:         "lo",
+				HardwareAddr: hwAddr,
+			},
+		},
+	}
+
+	if got := c.configureAddress(); !got {
+		t.Fatal("configureAddress() = false, want true")
+	}
+}
+
+// TestBasicConfigurer_configureAddress_IPv4_SendARPFails verifies that when the
+// gratuitous ARP send fails, configureAddress still returns true and handles
+// the error gracefully via a warning log.
+func TestBasicConfigurer_configureAddress_IPv4_SendARPFails(t *testing.T) {
+	t.Parallel()
+	mockLogger(t)
+	mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd { return exec.Command("true") })
+
+	old := linuxSendPacketWithProtocolFn
+	linuxSendPacketWithProtocolFn = func(_ net.Interface, _ []byte, _ uint16) error {
+		return errors.New("mock ARP send error")
+	}
+	t.Cleanup(func() { linuxSendPacketWithProtocolFn = old })
+
+	c := &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			VIP:     netip.MustParseAddr("192.168.1.100"),
+			Netmask: net.CIDRMask(24, 32),
+			Iface: net.Interface{
+				Name:         "lo",
+				HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+			},
+		},
+	}
+
+	if got := c.configureAddress(); !got {
+		t.Fatal("configureAddress() = false, want true even when ARP send fails")
 	}
 }
 

--- a/ipmanager/basicConfigurer_linux_test.go
+++ b/ipmanager/basicConfigurer_linux_test.go
@@ -14,8 +14,73 @@ import (
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
-	"go.uber.org/zap"
 )
+
+// ---------------------------------------------------------------------------
+// test helpers
+// ---------------------------------------------------------------------------
+
+func mockExecCommand(t *testing.T, fn func(string, ...string) *exec.Cmd) {
+	old := execCommand
+	execCommand = fn
+	t.Cleanup(func() { execCommand = old })
+}
+
+func mockSend(t *testing.T, fn func(net.Interface, []byte, uint16) error) {
+	old := linuxSendPacketWithProtocolFn
+	linuxSendPacketWithProtocolFn = fn
+	t.Cleanup(func() { linuxSendPacketWithProtocolFn = old })
+}
+
+func mockInterfaceAddrs(t *testing.T, fn func(string) ([]net.Addr, error)) {
+	old := interfaceAddrsFn
+	interfaceAddrsFn = fn
+	t.Cleanup(func() { interfaceAddrsFn = old })
+}
+
+// execOK and execFail stand in for the `ip` command.
+func execOK(string, ...string) *exec.Cmd   { return exec.Command("true") }
+func execFail(string, ...string) *exec.Cmd { return exec.Command("sh", "-c", "exit 1") }
+
+func mustCIDR(t *testing.T, s string) net.Addr {
+	t.Helper()
+	ip, ipNet, err := net.ParseCIDR(s)
+	if err != nil {
+		t.Fatalf("bad test CIDR %q: %v", s, err)
+	}
+	return &net.IPNet{IP: ip, Mask: ipNet.Mask}
+}
+
+// linkLocalAddrs is the address list of a typical dual-stack interface.
+func linkLocalAddrs(t *testing.T) []net.Addr {
+	t.Helper()
+	return []net.Addr{
+		mustCIDR(t, "192.168.1.5/24"),
+		mustCIDR(t, "fe80::1/64"),
+	}
+}
+
+// loopbackAddrs is what Linux `lo` actually carries: no link-local unicast.
+func loopbackAddrs(t *testing.T) []net.Addr {
+	t.Helper()
+	return []net.Addr{
+		mustCIDR(t, "127.0.0.1/8"),
+		mustCIDR(t, "::1/128"),
+	}
+}
+
+func testConfigurer(vip string, mask net.IPMask) *BasicConfigurer {
+	return &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			VIP:     netip.MustParseAddr(vip),
+			Netmask: mask,
+			Iface: net.Interface{
+				Name:         "eth0",
+				HardwareAddr: net.HardwareAddr{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF},
+			},
+		},
+	}
+}
 
 // ---------------------------------------------------------------------------
 // htons
@@ -29,38 +94,17 @@ func TestHtons(t *testing.T) {
 		input uint16
 		want  uint16
 	}{
-		{
-			name:  "zero",
-			input: 0x0000,
-			want:  0x0000,
-		},
-		{
-			name:  "ETH_P_ARP",
-			input: 0x0806,
-			want:  0x0608,
-		},
-		{
-			name:  "ETH_P_ALL",
-			input: 0x0003,
-			want:  0x0300,
-		},
-		{
-			name:  "max value",
-			input: 0xFFFF,
-			want:  0xFFFF,
-		},
-		{
-			name:  "asymmetric value",
-			input: 0x1234,
-			want:  0x3412,
-		},
+		{name: "zero", input: 0x0000, want: 0x0000},
+		{name: "ETH_P_ARP", input: 0x0806, want: 0x0608},
+		{name: "ETH_P_ALL", input: 0x0003, want: 0x0300},
+		{name: "max value", input: 0xFFFF, want: 0xFFFF},
+		{name: "asymmetric value", input: 0x1234, want: 0x3412},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := htons(tt.input)
-			if got != tt.want {
+			if got := htons(tt.input); got != tt.want {
 				t.Errorf("htons(0x%04X) = 0x%04X, want 0x%04X", tt.input, got, tt.want)
 			}
 		})
@@ -71,57 +115,590 @@ func TestHtons_Reversible(t *testing.T) {
 	t.Parallel()
 
 	// htons should be its own inverse (calling it twice returns the original value)
-	testValues := []uint16{0x0000, 0x0001, 0x0100, 0x1234, 0xABCD, 0xFFFF}
-	for _, val := range testValues {
-		reversed := htons(htons(val))
-		if reversed != val {
+	for _, val := range []uint16{0x0000, 0x0001, 0x0100, 0x1234, 0xABCD, 0xFFFF} {
+		if reversed := htons(htons(val)); reversed != val {
 			t.Errorf("htons(htons(0x%04X)) = 0x%04X, want 0x%04X", val, reversed, val)
 		}
 	}
 }
 
 // ---------------------------------------------------------------------------
-// sendPacketLinux
+// pickLinkLocal
 // ---------------------------------------------------------------------------
 
-func TestSendPacketLinux_LoopbackInterface(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("sendPacketLinux tests require root privileges")
+func TestPickLinkLocal(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		addrs   []net.Addr
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "no addresses",
+			addrs:   nil,
+			wantErr: true,
+		},
+		{
+			name:    "IPv4 only",
+			addrs:   []net.Addr{mustCIDR(t, "192.168.1.5/24")},
+			wantErr: true,
+		},
+		{
+			name:    "loopback only, ::1 is not link-local unicast",
+			addrs:   loopbackAddrs(t),
+			wantErr: true,
+		},
+		{
+			name:    "global unicast only",
+			addrs:   []net.Addr{mustCIDR(t, "2001:db8::10/64")},
+			wantErr: true,
+		},
+		{
+			name:    "IPv4 link-local is not a match",
+			addrs:   []net.Addr{mustCIDR(t, "169.254.1.1/16")},
+			wantErr: true,
+		},
+		{
+			name:  "link-local present",
+			addrs: linkLocalAddrs(t),
+			want:  "fe80::1",
+		},
+		{
+			name:  "first link-local wins",
+			addrs: []net.Addr{mustCIDR(t, "fe80::1/64"), mustCIDR(t, "fe80::2/64")},
+			want:  "fe80::1",
+		},
+		{
+			name:  "IPAddr form is accepted",
+			addrs: []net.Addr{&net.IPAddr{IP: net.ParseIP("fe80::abcd")}},
+			want:  "fe80::abcd",
+		},
+		{
+			name:  "unknown Addr types are skipped",
+			addrs: []net.Addr{&net.TCPAddr{IP: net.ParseIP("fe80::dead")}, mustCIDR(t, "fe80::1/64")},
+			want:  "fe80::1",
+		},
 	}
 
-	// Get the loopback interface
-	lo, err := net.InterfaceByName("lo")
-	if err != nil {
-		t.Fatalf("failed to get loopback interface: %v", err)
-	}
-
-	// Create a minimal Ethernet frame (too small to be valid, but enough to test the syscall)
-	packet := make([]byte, 64)
-	for i := range packet {
-		packet[i] = 0x00
-	}
-
-	// Try to send the packet - this exercises the full sendPacketLinux code path:
-	// 1. Socket creation
-	// 2. Bind
-	// 3. Sendto
-	err = sendPacketLinux(*lo, packet)
-
-	// Sending on loopback might fail or succeed depending on kernel configuration
-	// We just want to ensure the function doesn't panic and handles errors appropriately
-	if err != nil {
-		// Expected possible errors include permission denied or invalid argument
-		if errno, ok := err.(syscall.Errno); ok {
-			switch errno {
-			case syscall.EPERM, syscall.EACCES:
-				t.Logf("sendPacketLinux returned permission error (expected in some environments): %v", err)
-			case syscall.EINVAL, syscall.ENETDOWN:
-				t.Logf("sendPacketLinux returned network error (acceptable): %v", err)
-			default:
-				t.Logf("sendPacketLinux returned error: %v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := pickLinkLocal("eth0", tt.addrs)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("pickLinkLocal() = %s, want an error", got)
+				}
+				if !bytes.Contains([]byte(err.Error()), []byte("eth0")) {
+					t.Errorf("error %q does not name the interface", err)
+				}
+				return
 			}
+			if err != nil {
+				t.Fatalf("pickLinkLocal() error = %v", err)
+			}
+			if !got.Equal(net.ParseIP(tt.want)) {
+				t.Errorf("pickLinkLocal() = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// linkLocalAddress
+// ---------------------------------------------------------------------------
+
+func TestBasicConfigurer_linkLocalAddress(t *testing.T) {
+	mockInterfaceAddrs(t, func(name string) ([]net.Addr, error) {
+		if name != "eth0" {
+			t.Errorf("looked up interface %q, want eth0", name)
+		}
+		return linkLocalAddrs(t), nil
+	})
+
+	c := testConfigurer("2001:db8::10", net.CIDRMask(64, 128))
+	got, err := c.linkLocalAddress()
+	if err != nil {
+		t.Fatalf("linkLocalAddress() error = %v", err)
+	}
+	if !got.Equal(net.ParseIP("fe80::1")) {
+		t.Errorf("linkLocalAddress() = %s, want fe80::1", got)
+	}
+}
+
+func TestBasicConfigurer_linkLocalAddress_LookupFails(t *testing.T) {
+	wantErr := errors.New("no such interface")
+	mockInterfaceAddrs(t, func(string) ([]net.Addr, error) { return nil, wantErr })
+
+	c := testConfigurer("2001:db8::10", net.CIDRMask(64, 128))
+	if _, err := c.linkLocalAddress(); !errors.Is(err, wantErr) {
+		t.Fatalf("linkLocalAddress() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestBasicConfigurer_linkLocalAddress_MissingInterface(t *testing.T) {
+	t.Parallel()
+
+	c := &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			Iface: net.Interface{Name: "definitely-not-a-real-interface"},
+		},
+	}
+
+	if _, err := c.linkLocalAddress(); err == nil {
+		t.Fatal("linkLocalAddress() expected an error for a missing interface, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// configureAddress, IPv6 Neighbor Advertisement
+// ---------------------------------------------------------------------------
+
+// assertNAEthernet checks the link layer of an unsolicited NA.
+func assertNAEthernet(t *testing.T, parsed gopacket.Packet, srcMAC net.HardwareAddr) {
+	t.Helper()
+
+	ethLayer := parsed.Layer(layers.LayerTypeEthernet)
+	if ethLayer == nil {
+		t.Fatal("missing Ethernet layer")
+	}
+	eth := ethLayer.(*layers.Ethernet)
+
+	wantMulticastMAC := net.HardwareAddr{0x33, 0x33, 0x00, 0x00, 0x00, 0x01}
+	if !bytes.Equal(eth.DstMAC, wantMulticastMAC) {
+		t.Errorf("Ethernet DstMAC = %v, want all-nodes multicast %v", eth.DstMAC, wantMulticastMAC)
+	}
+	if !bytes.Equal(eth.SrcMAC, srcMAC) {
+		t.Errorf("Ethernet SrcMAC = %v, want %v", eth.SrcMAC, srcMAC)
+	}
+	if eth.EthernetType != layers.EthernetTypeIPv6 {
+		t.Errorf("Ethernet EthernetType = %v, want IPv6", eth.EthernetType)
+	}
+}
+
+// assertNAIPv6 checks the network layer of an unsolicited NA.
+func assertNAIPv6(t *testing.T, parsed gopacket.Packet, wantSrc net.IP) {
+	t.Helper()
+
+	ipv6Layer := parsed.Layer(layers.LayerTypeIPv6)
+	if ipv6Layer == nil {
+		t.Fatal("missing IPv6 layer")
+	}
+	ipv6 := ipv6Layer.(*layers.IPv6)
+
+	if ipv6.Version != 6 {
+		t.Errorf("IPv6 Version = %d, want 6", ipv6.Version)
+	}
+	if ipv6.HopLimit != 255 {
+		t.Errorf("IPv6 HopLimit = %d, want 255", ipv6.HopLimit)
+	}
+	if ipv6.NextHeader != layers.IPProtocolICMPv6 {
+		t.Errorf("IPv6 NextHeader = %v, want ICMPv6", ipv6.NextHeader)
+	}
+	if allNodes := net.ParseIP("ff02::1"); !ipv6.DstIP.Equal(allNodes) {
+		t.Errorf("IPv6 DstIP = %s, want %s", ipv6.DstIP, allNodes)
+	}
+	// The VIP is still tentative under DAD, so the NA must be sourced from the
+	// interface's link-local address.
+	if !ipv6.SrcIP.Equal(wantSrc) {
+		t.Errorf("IPv6 SrcIP = %s, want the link-local address %s", ipv6.SrcIP, wantSrc)
+	}
+}
+
+// assertNAMessage checks the ICMPv6 header and the advertisement itself.
+func assertNAMessage(t *testing.T, parsed gopacket.Packet, wantTarget netip.Addr, wantMAC net.HardwareAddr) {
+	t.Helper()
+
+	icmpLayer := parsed.Layer(layers.LayerTypeICMPv6)
+	if icmpLayer == nil {
+		t.Fatal("missing ICMPv6 layer")
+	}
+	icmp := icmpLayer.(*layers.ICMPv6)
+	if icmp.TypeCode.Type() != layers.ICMPv6TypeNeighborAdvertisement {
+		t.Errorf("ICMPv6 Type = %v, want NA (%d)", icmp.TypeCode.Type(), layers.ICMPv6TypeNeighborAdvertisement)
+	}
+	if icmp.Checksum == 0 {
+		t.Error("ICMPv6 checksum was not computed")
+	}
+
+	naLayer := parsed.Layer(layers.LayerTypeICMPv6NeighborAdvertisement)
+	if naLayer == nil {
+		t.Fatal("missing ICMPv6NeighborAdvertisement layer")
+	}
+	na := naLayer.(*layers.ICMPv6NeighborAdvertisement)
+
+	if na.Flags&0x20 == 0 {
+		t.Errorf("NA Override flag not set, flags = 0x%x", na.Flags)
+	}
+	if na.Flags&0x40 != 0 {
+		t.Errorf("NA Solicited flag must be clear on an unsolicited NA, flags = 0x%x", na.Flags)
+	}
+	if !net.IP(na.TargetAddress).Equal(net.IP(wantTarget.AsSlice())) {
+		t.Errorf("NA TargetAddress = %s, want %s", na.TargetAddress, wantTarget)
+	}
+	if len(na.Options) != 1 {
+		t.Fatalf("NA Options length = %d, want 1", len(na.Options))
+	}
+	if na.Options[0].Type != layers.ICMPv6OptTargetAddress {
+		t.Errorf("NA Option Type = %v, want TargetLinkLayerAddress", na.Options[0].Type)
+	}
+	if !bytes.Equal(na.Options[0].Data, wantMAC) {
+		t.Errorf("NA Option Data = %v, want MAC %v", na.Options[0].Data, wantMAC)
+	}
+}
+
+// TestBasicConfigurer_configureAddress_IPv6_NAPacketContent validates the full
+// content of the unsolicited Neighbor Advertisement that is sent after a new
+// IPv6 address is bound to the interface.
+func TestBasicConfigurer_configureAddress_IPv6_NAPacketContent(t *testing.T) {
+	mockLogger(t)
+	mockExecCommand(t, execOK)
+	mockInterfaceAddrs(t, func(string) ([]net.Addr, error) { return linkLocalAddrs(t), nil })
+
+	c := testConfigurer("2001:db8::10", net.CIDRMask(64, 128))
+
+	sendCalled := false
+	mockSend(t, func(iface net.Interface, packet []byte, protocol uint16) error {
+		sendCalled = true
+
+		if iface.Name != c.Iface.Name {
+			t.Errorf("sent on interface %q, want %q", iface.Name, c.Iface.Name)
+		}
+		if protocol != syscall.ETH_P_IPV6 {
+			t.Fatalf("protocol = %d, want ETH_P_IPV6 (%d)", protocol, syscall.ETH_P_IPV6)
+		}
+
+		parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
+		assertNAEthernet(t, parsed, c.Iface.HardwareAddr)
+		assertNAIPv6(t, parsed, net.ParseIP("fe80::1"))
+		assertNAMessage(t, parsed, c.VIP, c.Iface.HardwareAddr)
+		return nil
+	})
+
+	if got := c.configureAddress(); !got {
+		t.Fatal("configureAddress() = false, want true")
+	}
+	if !sendCalled {
+		t.Fatal("the NA send seam was never invoked, so the assertions above did not run")
+	}
+}
+
+// TestBasicConfigurer_configureAddress_IPv6_NoLinkLocal verifies that an
+// interface without an IPv6 link-local address produces a warning and no send,
+// while the address itself stays configured.
+func TestBasicConfigurer_configureAddress_IPv6_NoLinkLocal(t *testing.T) {
+	mockLogger(t)
+	mockExecCommand(t, execOK)
+	// Exactly what Linux loopback carries: no fe80::/10 address.
+	mockInterfaceAddrs(t, func(string) ([]net.Addr, error) { return loopbackAddrs(t), nil })
+	mockSend(t, func(net.Interface, []byte, uint16) error {
+		t.Fatal("send must not be called when no IPv6 link-local address is available")
+		return nil
+	})
+
+	c := testConfigurer("2001:db8::10", net.CIDRMask(64, 128))
+	if got := c.configureAddress(); !got {
+		t.Fatal("configureAddress() = false, want true, the address was still added")
+	}
+}
+
+// TestBasicConfigurer_configureAddress_IPv6_RunAddrConfigFails verifies that
+// when runAddressConfiguration fails for an IPv6 VIP, configureAddress returns
+// false and never attempts to send a Neighbor Advertisement.
+func TestBasicConfigurer_configureAddress_IPv6_RunAddrConfigFails(t *testing.T) {
+	mockLogger(t)
+	mockExecCommand(t, execFail)
+	mockInterfaceAddrs(t, func(string) ([]net.Addr, error) { return linkLocalAddrs(t), nil })
+	mockSend(t, func(net.Interface, []byte, uint16) error {
+		t.Fatal("send must not be called when runAddressConfiguration fails")
+		return nil
+	})
+
+	c := testConfigurer("2001:db8::10", net.CIDRMask(64, 128))
+	if got := c.configureAddress(); got {
+		t.Fatal("configureAddress() = true, want false when runAddressConfiguration fails")
+	}
+}
+
+// TestBasicConfigurer_configureAddress_IPv6_SendNAFails verifies that when the
+// NA send fails, configureAddress still returns true (the address was added)
+// and handles the error gracefully.
+func TestBasicConfigurer_configureAddress_IPv6_SendNAFails(t *testing.T) {
+	mockLogger(t)
+	mockExecCommand(t, execOK)
+	mockInterfaceAddrs(t, func(string) ([]net.Addr, error) { return linkLocalAddrs(t), nil })
+
+	sendCalled := false
+	mockSend(t, func(_ net.Interface, _ []byte, protocol uint16) error {
+		sendCalled = true
+		if protocol != syscall.ETH_P_IPV6 {
+			t.Errorf("protocol = %d, want ETH_P_IPV6 (%d)", protocol, syscall.ETH_P_IPV6)
+		}
+		return errors.New("mock send error: permission denied")
+	})
+
+	c := testConfigurer("2001:db8::10", net.CIDRMask(64, 128))
+	if got := c.configureAddress(); !got {
+		t.Fatal("configureAddress() = false, want true even when the NA send fails")
+	}
+	if !sendCalled {
+		t.Fatal("the NA send seam was never invoked")
+	}
+}
+
+// TestBasicConfigurer_configureAddress_IPv6_ComposeNAFails covers the branch
+// where building the NA packet fails: the address stays configured and nothing
+// is put on the wire.
+func TestBasicConfigurer_configureAddress_IPv6_ComposeNAFails(t *testing.T) {
+	mockLogger(t)
+	mockExecCommand(t, execOK)
+	mockInterfaceAddrs(t, func(string) ([]net.Addr, error) { return linkLocalAddrs(t), nil })
+	mockSerialize(t, func(gopacket.SerializeBuffer, gopacket.SerializeOptions, ...gopacket.SerializableLayer) error {
+		return errors.New("mock serialize error")
+	})
+	mockSend(t, func(net.Interface, []byte, uint16) error {
+		t.Fatal("send must not be called when the NA cannot be composed")
+		return nil
+	})
+
+	c := testConfigurer("2001:db8::10", net.CIDRMask(64, 128))
+	if got := c.configureAddress(); !got {
+		t.Fatal("configureAddress() = false, want true, the address was still added")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// configureAddress, IPv4 gratuitous ARP
+// ---------------------------------------------------------------------------
+
+// TestBasicConfigurer_configureAddress_IPv4 verifies the IPv4 branch: after a
+// successful address add, a gratuitous ARP is composed and sent on the
+// interface with the ARP ethertype.
+func TestBasicConfigurer_configureAddress_IPv4(t *testing.T) {
+	mockLogger(t)
+	mockExecCommand(t, execOK)
+	mockInterfaceAddrs(t, func(string) ([]net.Addr, error) {
+		t.Error("the IPv4 path must not look up link-local addresses")
+		return nil, errors.New("unexpected lookup")
+	})
+
+	c := testConfigurer("192.168.1.100", net.CIDRMask(24, 32))
+	hwAddr := c.Iface.HardwareAddr
+
+	sendCalled := false
+	mockSend(t, func(_ net.Interface, packet []byte, protocol uint16) error {
+		sendCalled = true
+		if protocol != syscall.ETH_P_ARP {
+			t.Errorf("protocol = %d, want ETH_P_ARP (%d)", protocol, syscall.ETH_P_ARP)
+		}
+		parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
+		ethLayer := parsed.Layer(layers.LayerTypeEthernet)
+		if ethLayer == nil {
+			t.Fatal("missing Ethernet layer in ARP packet")
+		}
+		if eth := ethLayer.(*layers.Ethernet); eth.EthernetType != layers.EthernetTypeARP {
+			t.Errorf("Ethernet type = %v, want ARP", eth.EthernetType)
+		}
+		arpLayer := parsed.Layer(layers.LayerTypeARP)
+		if arpLayer == nil {
+			t.Fatal("missing ARP layer")
+		}
+		arp := arpLayer.(*layers.ARP)
+		if !bytes.Equal(arp.SourceProtAddress, c.VIP.AsSlice()) {
+			t.Errorf("ARP SourceProtAddress = %v, want %v", arp.SourceProtAddress, c.VIP.AsSlice())
+		}
+		if !bytes.Equal(arp.SourceHwAddress, hwAddr) {
+			t.Errorf("ARP SourceHwAddress = %v, want %v", arp.SourceHwAddress, hwAddr)
+		}
+		return nil
+	})
+
+	if got := c.configureAddress(); !got {
+		t.Fatal("configureAddress() = false, want true")
+	}
+	if !sendCalled {
+		t.Fatal("the ARP send seam was never invoked, so the assertions above did not run")
+	}
+}
+
+// TestBasicConfigurer_configureAddress_IPv4In6 verifies that a ::ffff:a.b.c.d
+// VIP takes the ARP path, not the Neighbor Advertisement path, even though
+// netip.Addr.Is6 reports true for it.
+func TestBasicConfigurer_configureAddress_IPv4In6(t *testing.T) {
+	mockLogger(t)
+	mockExecCommand(t, execOK)
+	mockInterfaceAddrs(t, func(string) ([]net.Addr, error) {
+		t.Error("an IPv4-in-IPv6 VIP must not take the Neighbor Advertisement path")
+		return nil, errors.New("unexpected lookup")
+	})
+
+	c := testConfigurer("::ffff:192.0.2.1", net.CIDRMask(24, 32))
+
+	sendCalled := false
+	mockSend(t, func(_ net.Interface, packet []byte, protocol uint16) error {
+		sendCalled = true
+		if protocol != syscall.ETH_P_ARP {
+			t.Errorf("protocol = %d, want ETH_P_ARP (%d)", protocol, syscall.ETH_P_ARP)
+		}
+		parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
+		arpLayer := parsed.Layer(layers.LayerTypeARP)
+		if arpLayer == nil {
+			t.Fatal("missing ARP layer")
+		}
+		arp := arpLayer.(*layers.ARP)
+		want := net.ParseIP("192.0.2.1").To4()
+		if !bytes.Equal(arp.SourceProtAddress, want) {
+			t.Errorf("ARP SourceProtAddress = %v, want the unmapped %v", arp.SourceProtAddress, want)
+		}
+		return nil
+	})
+
+	if got := c.configureAddress(); !got {
+		t.Fatal("configureAddress() = false, want true")
+	}
+	if !sendCalled {
+		t.Fatal("the ARP send seam was never invoked")
+	}
+}
+
+// TestBasicConfigurer_configureAddress_IPv4_SendARPFails verifies that when the
+// gratuitous ARP send fails, configureAddress still returns true and handles
+// the error gracefully via a warning log.
+func TestBasicConfigurer_configureAddress_IPv4_SendARPFails(t *testing.T) {
+	mockLogger(t)
+	mockExecCommand(t, execOK)
+
+	sendCalled := false
+	mockSend(t, func(net.Interface, []byte, uint16) error {
+		sendCalled = true
+		return errors.New("mock ARP send error")
+	})
+
+	c := testConfigurer("192.168.1.100", net.CIDRMask(24, 32))
+	if got := c.configureAddress(); !got {
+		t.Fatal("configureAddress() = false, want true even when the ARP send fails")
+	}
+	if !sendCalled {
+		t.Fatal("the ARP send seam was never invoked")
+	}
+}
+
+// TestBasicConfigurer_configureAddress_IPv4_ComposeARPFails covers the branch
+// where building the ARP packet fails.
+func TestBasicConfigurer_configureAddress_IPv4_ComposeARPFails(t *testing.T) {
+	mockLogger(t)
+	mockExecCommand(t, execOK)
+	mockSerialize(t, func(gopacket.SerializeBuffer, gopacket.SerializeOptions, ...gopacket.SerializableLayer) error {
+		return errors.New("mock serialize error")
+	})
+	mockSend(t, func(net.Interface, []byte, uint16) error {
+		t.Fatal("send must not be called when the ARP packet cannot be composed")
+		return nil
+	})
+
+	c := testConfigurer("192.168.1.100", net.CIDRMask(24, 32))
+	if got := c.configureAddress(); !got {
+		t.Fatal("configureAddress() = false, want true, the address was still added")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// deconfigureAddress
+// ---------------------------------------------------------------------------
+
+func TestBasicConfigurer_deconfigureAddress_Mocked(t *testing.T) {
+	tests := []struct {
+		name string
+		vip  string
+		mask net.IPMask
+		cmd  func(string, ...string) *exec.Cmd
+		want bool
+	}{
+		{name: "IPv4 success", vip: "192.168.1.100", mask: net.CIDRMask(24, 32), cmd: execOK, want: true},
+		{name: "IPv4 failure", vip: "192.168.1.100", mask: net.CIDRMask(24, 32), cmd: execFail, want: false},
+		{name: "IPv6 success", vip: "2001:db8::10", mask: net.CIDRMask(64, 128), cmd: execOK, want: true},
+		{name: "IPv6 failure", vip: "2001:db8::10", mask: net.CIDRMask(64, 128), cmd: execFail, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockLogger(t)
+
+			var gotArgs []string
+			mockExecCommand(t, func(name string, args ...string) *exec.Cmd {
+				gotArgs = append([]string{name}, args...)
+				return tt.cmd(name, args...)
+			})
+
+			c := testConfigurer(tt.vip, tt.mask)
+			if got := c.deconfigureAddress(); got != tt.want {
+				t.Errorf("deconfigureAddress() = %v, want %v", got, tt.want)
+			}
+
+			want := []string{"ip", "addr", "delete", c.getCIDR(), "dev", c.Iface.Name}
+			if len(gotArgs) != len(want) {
+				t.Fatalf("ran %v, want %v", gotArgs, want)
+			}
+			for i := range want {
+				if gotArgs[i] != want[i] {
+					t.Fatalf("ran %v, want %v", gotArgs, want)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runAddressConfiguration
+// ---------------------------------------------------------------------------
+
+func TestBasicConfigurer_runAddressConfiguration_ErrorExit(t *testing.T) {
+	mockLogger(t)
+	mockExecCommand(t, execFail)
+
+	c := testConfigurer("2001:db8::10", net.CIDRMask(64, 128))
+	if c.runAddressConfiguration("add") {
+		t.Fatal("runAddressConfiguration() = true, want false")
+	}
+}
+
+// TestBasicConfigurer_runAddressConfiguration_CommandMissing covers the
+// non-ExitError branch, where the `ip` binary itself cannot be started.
+func TestBasicConfigurer_runAddressConfiguration_CommandMissing(t *testing.T) {
+	mockLogger(t)
+	mockExecCommand(t, func(string, ...string) *exec.Cmd {
+		return exec.Command("definitely-not-a-real-binary-zzz")
+	})
+
+	c := testConfigurer("192.168.1.100", net.CIDRMask(24, 32))
+	if c.runAddressConfiguration("add") {
+		t.Fatal("runAddressConfiguration() = true, want false when the command cannot be started")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// sendPacketLinux and sendPacketLinuxWithProtocol (require root)
+// ---------------------------------------------------------------------------
+
+// firstEthernetInterface returns an interface that is up and has a real MAC, or
+// nil if the host has none.
+func firstEthernetInterface(t *testing.T) *net.Interface {
+	t.Helper()
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatalf("failed to get network interfaces: %v", err)
+	}
+	for i := range ifaces {
+		iface := &ifaces[i]
+		if iface.Flags&net.FlagUp != 0 &&
+			len(iface.HardwareAddr) == 6 &&
+			iface.HardwareAddr.String() != "00:00:00:00:00:00" {
+			return iface
 		}
 	}
+	return nil
 }
 
 func TestSendPacketLinux_ValidInterface(t *testing.T) {
@@ -129,30 +706,11 @@ func TestSendPacketLinux_ValidInterface(t *testing.T) {
 		t.Skip("sendPacketLinux tests require root privileges")
 	}
 
-	// Find any available network interface (preferably not loopback)
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		t.Fatalf("failed to get network interfaces: %v", err)
-	}
-
-	var testIface *net.Interface
-	for i := range ifaces {
-		iface := &ifaces[i]
-		// Look for an interface that is up and has a valid hardware address
-		if iface.Flags&net.FlagUp != 0 &&
-			iface.HardwareAddr != nil &&
-			len(iface.HardwareAddr) == 6 &&
-			iface.HardwareAddr.String() != "00:00:00:00:00:00" {
-			testIface = iface
-			break
-		}
-	}
-
+	testIface := firstEthernetInterface(t)
 	if testIface == nil {
 		t.Skip("no suitable network interface found for testing")
 	}
 
-	// Create a properly formatted Ethernet/ARP packet
 	c := &BasicConfigurer{
 		IPConfiguration: &IPConfiguration{
 			VIP:     netip.MustParseAddr("192.0.2.1"),
@@ -166,15 +724,39 @@ func TestSendPacketLinux_ValidInterface(t *testing.T) {
 		t.Fatalf("failed to create gratuitous ARP packet: %v", err)
 	}
 
-	// Send the packet - this exercises all code paths in sendPacketLinux
-	err = sendPacketLinux(*testIface, packet)
+	// A well-formed frame on a real, up interface must go out cleanly.
+	if err := sendPacketLinux(*testIface, packet); err != nil {
+		t.Errorf("sendPacketLinux() error = %v, want nil on %s", err, testIface.Name)
+	}
+}
 
-	// The send might succeed or fail depending on network configuration
-	// We're mainly testing that all code paths execute without panic
+func TestSendPacketLinuxWithProtocol_IPv6(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("sendPacketLinuxWithProtocol tests require root privileges")
+	}
+
+	testIface := firstEthernetInterface(t)
+	if testIface == nil {
+		t.Skip("no suitable network interface found for testing")
+	}
+
+	c := &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			VIP:     netip.MustParseAddr("2001:db8::10"),
+			Netmask: net.CIDRMask(64, 128),
+			Iface:   *testIface,
+		},
+	}
+
+	packet, err := c.createGratuitousNA(net.ParseIP("fe80::1"))
 	if err != nil {
-		t.Logf("sendPacketLinux returned error (acceptable): %v", err)
-	} else {
-		t.Log("sendPacketLinux succeeded")
+		t.Fatalf("failed to create Neighbor Advertisement: %v", err)
+	}
+
+	// Exercise the real raw socket with the IPv6 ethertype, which is otherwise
+	// only ever reached through the mocked seam.
+	if err := sendPacketLinuxWithProtocol(*testIface, packet, syscall.ETH_P_IPV6); err != nil {
+		t.Errorf("sendPacketLinuxWithProtocol() error = %v, want nil on %s", err, testIface.Name)
 	}
 }
 
@@ -183,467 +765,27 @@ func TestSendPacketLinux_InvalidInterface(t *testing.T) {
 		t.Skip("sendPacketLinux tests require root privileges")
 	}
 
-	// Create an interface with an invalid index
-	invalidIface := net.Interface{
-		Index: 99999, // Very unlikely to exist
-		Name:  "nonexistent0",
-	}
+	// An interface index that cannot exist must be rejected by bind().
+	invalidIface := net.Interface{Index: 99999, Name: "nonexistent0"}
 
-	packet := make([]byte, 64)
-	err := sendPacketLinux(invalidIface, packet)
-
-	// Should fail when trying to bind or send
+	err := sendPacketLinux(invalidIface, make([]byte, 64))
 	if err == nil {
-		t.Log("sendPacketLinux unexpectedly succeeded with invalid interface (kernel may have allowed it)")
-	} else {
-		t.Logf("sendPacketLinux correctly failed with invalid interface: %v", err)
+		t.Fatal("sendPacketLinux() = nil, want an error for a nonexistent interface index")
 	}
-}
-
-func TestSendPacketLinux_EmptyPacket(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("sendPacketLinux tests require root privileges")
-	}
-
-	lo, err := net.InterfaceByName("lo")
-	if err != nil {
-		t.Fatalf("failed to get loopback interface: %v", err)
-	}
-
-	// Try to send an empty packet
-	err = sendPacketLinux(*lo, []byte{})
-
-	// May succeed or fail, but should not panic
-	if err != nil {
-		t.Logf("sendPacketLinux with empty packet returned: %v", err)
-	}
-}
-
-func TestBasicConfigurer_linkLocalAddress(t *testing.T) {
-	t.Parallel()
-
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		t.Fatalf("failed to get interfaces: %v", err)
-	}
-
-	for i := range ifaces {
-		iface := ifaces[i]
-		addrs, err := iface.Addrs()
-		if err != nil {
-			continue
-		}
-		for _, addr := range addrs {
-			ip, _, err := net.ParseCIDR(addr.String())
-			if err != nil || ip == nil || ip.To4() != nil || !ip.IsLinkLocalUnicast() {
-				continue
-			}
-
-			c := &BasicConfigurer{
-				IPConfiguration: &IPConfiguration{Iface: iface},
-			}
-			got, err := c.linkLocalAddress()
-			if err != nil {
-				t.Fatalf("linkLocalAddress() error for %s: %v", iface.Name, err)
-			}
-			if !got.Equal(ip) {
-				t.Fatalf("linkLocalAddress() = %s, want %s", got, ip)
-			}
-			return
-		}
-	}
-
-	t.Skip("no IPv6 link-local address available on this machine")
-}
-
-func TestBasicConfigurer_linkLocalAddress_MissingInterface(t *testing.T) {
-	t.Parallel()
-
-	c := &BasicConfigurer{
-		IPConfiguration: &IPConfiguration{
-			Iface: net.Interface{Name: "definitely-not-a-real-interface"},
-		},
-	}
-
-	_, err := c.linkLocalAddress()
-	if err == nil {
-		t.Fatal("linkLocalAddress() expected an error for a missing interface, got nil")
-	}
-}
-
-func mockLogger(t *testing.T) {
-	old := log
-	log = zap.NewNop().Sugar()
-	t.Cleanup(func() { log = old })
-}
-
-func mockExecCommand(t *testing.T, fn func(string, ...string) *exec.Cmd) {
-	old := execCommand
-	execCommand = fn
-	t.Cleanup(func() { execCommand = old })
-}
-
-func mockIPv6Send(t *testing.T, fn func(net.Interface, []byte, uint16) error) {
-	old := linuxSendPacketWithProtocolFn
-	linuxSendPacketWithProtocolFn = fn
-	t.Cleanup(func() { linuxSendPacketWithProtocolFn = old })
-}
-
-func TestBasicConfigurer_configureAddress_IPv6(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name      string
-		iface     net.Interface
-		wantSend  bool
-		sendCheck func(net.Interface, []byte, uint16) error
-	}{
-		{
-			name:     "success",
-			iface:    net.Interface{Name: "lo"},
-			wantSend: true,
-			sendCheck: func(_ net.Interface, _ []byte, protocol uint16) error {
-				if protocol != syscall.ETH_P_IPV6 {
-					t.Fatalf("wrong protocol: got %d want %d", protocol, syscall.ETH_P_IPV6)
-				}
-				return nil
-			},
-		},
-		{
-			name:     "no-link-local",
-			iface:    net.Interface{Name: "loopback-test"},
-			wantSend: false,
-			sendCheck: func(_ net.Interface, _ []byte, _ uint16) error {
-				t.Fatal("send should not be called when no IPv6 link-local address is available")
-				return nil
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			mockLogger(t)
-			mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd { return exec.Command("true") })
-			mockIPv6Send(t, tt.sendCheck)
-
-			c := &BasicConfigurer{
-				IPConfiguration: &IPConfiguration{
-					VIP:     netip.MustParseAddr("2001:db8::10"),
-					Netmask: net.CIDRMask(64, 128),
-					Iface:   tt.iface,
-				},
-			}
-
-			if !c.configureAddress() {
-				t.Fatal("configureAddress() = false, want true")
-			}
-		})
-	}
-}
-
-// TestBasicConfigurer_configureAddress_IPv6_RunAddrConfigFails verifies that
-// when runAddressConfiguration fails for an IPv6 VIP, configureAddress returns
-// false and never attempts to send a Neighbor Advertisement.
-func TestBasicConfigurer_configureAddress_IPv6_RunAddrConfigFails(t *testing.T) {
-	t.Parallel()
-	mockLogger(t)
-	mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd {
-		return exec.Command("sh", "-c", "exit 1")
-	})
-
-	sendCalled := false
-	mockIPv6Send(t, func(_ net.Interface, _ []byte, _ uint16) error {
-		sendCalled = true
-		t.Fatal("send should not be called when runAddressConfiguration fails")
-		return nil
-	})
-
-	c := &BasicConfigurer{
-		IPConfiguration: &IPConfiguration{
-			VIP:     netip.MustParseAddr("2001:db8::10"),
-			Netmask: net.CIDRMask(64, 128),
-			Iface:   net.Interface{Name: "lo"},
-		},
-	}
-
-	if got := c.configureAddress(); got {
-		t.Fatal("configureAddress() = true, want false when runAddressConfiguration fails")
-	}
-	if sendCalled {
-		t.Error("NA send was called despite runAddressConfiguration failure")
-	}
-}
-
-// TestBasicConfigurer_configureAddress_IPv6_SendNAFails verifies that
-// when the NA packet send fails, configureAddress still returns true
-// (the address was successfully added) and handles the error gracefully.
-func TestBasicConfigurer_configureAddress_IPv6_SendNAFails(t *testing.T) {
-	t.Parallel()
-	mockLogger(t)
-	mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd { return exec.Command("true") })
-
-	sendErr := errors.New("mock send error: permission denied")
-	mockIPv6Send(t, func(_ net.Interface, _ []byte, protocol uint16) error {
-		if protocol != syscall.ETH_P_IPV6 {
-			t.Fatalf("wrong protocol: got %d want %d", protocol, syscall.ETH_P_IPV6)
-		}
-		return sendErr
-	})
-
-	c := &BasicConfigurer{
-		IPConfiguration: &IPConfiguration{
-			VIP:     netip.MustParseAddr("2001:db8::10"),
-			Netmask: net.CIDRMask(64, 128),
-			Iface:   net.Interface{Name: "lo"},
-		},
-	}
-
-	// configureAddress should still return true because the address was added
-	// successfully; the NA send failure only produces a warning log.
-	if got := c.configureAddress(); !got {
-		t.Fatal("configureAddress() = false, want true even when NA send fails")
-	}
-}
-
-func validateIPv6NAEthernetLayer(t *testing.T, packet []byte, hwAddr net.HardwareAddr) {
-	t.Helper()
-	parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
-	ethLayer := parsed.Layer(layers.LayerTypeEthernet)
-	if ethLayer == nil {
-		t.Fatal("missing Ethernet layer")
-	}
-	eth := ethLayer.(*layers.Ethernet)
-	wantMulticastMAC := net.HardwareAddr{0x33, 0x33, 0x00, 0x00, 0x00, 0x01}
-	if !bytes.Equal(eth.DstMAC, wantMulticastMAC) {
-		t.Errorf("Ethernet DstMAC = %v, want all-nodes multicast %v", eth.DstMAC, wantMulticastMAC)
-	}
-	if !bytes.Equal(eth.SrcMAC, hwAddr) {
-		t.Errorf("Ethernet SrcMAC = %v, want %v", eth.SrcMAC, hwAddr)
-	}
-	if eth.EthernetType != layers.EthernetTypeIPv6 {
-		t.Errorf("Ethernet EthernetType = %v, want IPv6", eth.EthernetType)
-	}
-}
-
-func validateIPv6NAIPv6Layer(t *testing.T, packet []byte) {
-	t.Helper()
-	parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
-	ipv6Layer := parsed.Layer(layers.LayerTypeIPv6)
-	if ipv6Layer == nil {
-		t.Fatal("missing IPv6 layer")
-	}
-	ipv6 := ipv6Layer.(*layers.IPv6)
-	if ipv6.Version != 6 {
-		t.Errorf("IPv6 Version = %d, want 6", ipv6.Version)
-	}
-	if ipv6.HopLimit != 255 {
-		t.Errorf("IPv6 HopLimit = %d, want 255", ipv6.HopLimit)
-	}
-	if ipv6.NextHeader != layers.IPProtocolICMPv6 {
-		t.Errorf("IPv6 NextHeader = %v, want ICMPv6", ipv6.NextHeader)
-	}
-	allNodes := net.ParseIP("ff02::1")
-	if !ipv6.DstIP.Equal(allNodes) {
-		t.Errorf("IPv6 DstIP = %s, want %s", ipv6.DstIP, allNodes)
-	}
-	if ipv6.SrcIP == nil || !ipv6.SrcIP.IsLinkLocalUnicast() {
-		t.Errorf("IPv6 SrcIP = %s, want a link-local address", ipv6.SrcIP)
-	}
-}
-
-func validateIPv6NAICMPv6Layer(t *testing.T, packet []byte) {
-	t.Helper()
-	parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
-	icmpLayer := parsed.Layer(layers.LayerTypeICMPv6)
-	if icmpLayer == nil {
-		t.Fatal("missing ICMPv6 layer")
-	}
-	icmp := icmpLayer.(*layers.ICMPv6)
-	if icmp.TypeCode.Type() != layers.ICMPv6TypeNeighborAdvertisement {
-		t.Errorf("ICMPv6 Type = %v, want NA (%d)", icmp.TypeCode.Type(), layers.ICMPv6TypeNeighborAdvertisement)
-	}
-}
-
-func validateIPv6NANeighborAdvertisementLayer(t *testing.T, packet []byte, vipAddr netip.Addr, hwAddr net.HardwareAddr) {
-	t.Helper()
-	parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
-	naLayer := parsed.Layer(layers.LayerTypeICMPv6NeighborAdvertisement)
-	if naLayer == nil {
-		t.Fatal("missing ICMPv6NeighborAdvertisement layer")
-	}
-	na := naLayer.(*layers.ICMPv6NeighborAdvertisement)
-	if na.Flags&0x20 == 0 {
-		t.Errorf("NA Override flag not set, flags = 0x%x", na.Flags)
-	}
-	wantVIP := vipAddr.AsSlice()
-	if !net.IP(na.TargetAddress).Equal(net.IP(wantVIP)) {
-		t.Errorf("NA TargetAddress = %s, want %s", na.TargetAddress, vipAddr)
-	}
-	if len(na.Options) != 1 {
-		t.Fatalf("NA Options length = %d, want 1", len(na.Options))
-	}
-	if na.Options[0].Type != layers.ICMPv6OptTargetAddress {
-		t.Errorf("NA Option Type = %v, want TargetLinkLayerAddress", na.Options[0].Type)
-	}
-	if !bytes.Equal(na.Options[0].Data, hwAddr) {
-		t.Errorf("NA Option Data = %v, want MAC %v", na.Options[0].Data, hwAddr)
-	}
-}
-
-// TestBasicConfigurer_configureAddress_IPv6_NAPacketContent validates the
-// full content of the unsolicited Neighbor Advertisement packet that is sent
-// after a new IPv6 address is bound to the interface.
-func TestBasicConfigurer_configureAddress_IPv6_NAPacketContent(t *testing.T) {
-	t.Parallel()
-	mockLogger(t)
-	mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd { return exec.Command("true") })
-
-	vipAddr := netip.MustParseAddr("2001:db8::10")
-	hwAddr := net.HardwareAddr{0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF}
-
-	mockIPv6Send(t, func(_ net.Interface, packet []byte, protocol uint16) error {
-		if protocol != syscall.ETH_P_IPV6 {
-			t.Fatalf("protocol = %d, want ETH_P_IPV6 (%d)", protocol, syscall.ETH_P_IPV6)
-		}
-		validateIPv6NAEthernetLayer(t, packet, hwAddr)
-		validateIPv6NAIPv6Layer(t, packet)
-		validateIPv6NAICMPv6Layer(t, packet)
-		validateIPv6NANeighborAdvertisementLayer(t, packet, vipAddr, hwAddr)
-		return nil
-	})
-
-	c := &BasicConfigurer{
-		IPConfiguration: &IPConfiguration{
-			VIP:     vipAddr,
-			Netmask: net.CIDRMask(64, 128),
-			Iface: net.Interface{
-				Name:         "lo",
-				HardwareAddr: hwAddr,
-			},
-		},
-	}
-
-	if got := c.configureAddress(); !got {
-		t.Fatal("configureAddress() = false, want true")
-	}
-}
-
-func TestBasicConfigurer_runAddressConfiguration_ErrorExit(t *testing.T) {
-	mockLogger(t)
-	mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd {
-		return exec.Command("sh", "-c", "exit 1")
-	})
-
-	c := &BasicConfigurer{
-		IPConfiguration: &IPConfiguration{
-			VIP:     netip.MustParseAddr("2001:db8::10"),
-			Netmask: net.CIDRMask(64, 128),
-			Iface:   net.Interface{Name: "lo"},
-		},
-	}
-
-	if c.runAddressConfiguration("add") {
-		t.Fatal("runAddressConfiguration() = true, want false")
-	}
-}
-
-// TestBasicConfigurer_configureAddress_IPv4_MockedSend verifies the IPv4 branch
-// of configureAddress: after a successful address add, a gratuitous ARP is
-// composed and sent on the interface.
-func TestBasicConfigurer_configureAddress_IPv4_MockedSend(t *testing.T) {
-	t.Parallel()
-	mockLogger(t)
-	mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd { return exec.Command("true") })
-
-	vipAddr := netip.MustParseAddr("192.168.1.100")
-	hwAddr := net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}
-
-	old := linuxSendPacketWithProtocolFn
-	linuxSendPacketWithProtocolFn = func(_ net.Interface, packet []byte, protocol uint16) error {
-		if protocol != syscall.ETH_P_ARP {
-			t.Errorf("protocol = %d, want ETH_P_ARP (%d)", protocol, syscall.ETH_P_ARP)
-		}
-		parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
-		ethLayer := parsed.Layer(layers.LayerTypeEthernet)
-		if ethLayer == nil {
-			t.Fatal("missing Ethernet layer in ARP packet")
-		}
-		eth := ethLayer.(*layers.Ethernet)
-		if eth.EthernetType != layers.EthernetTypeARP {
-			t.Errorf("Ethernet type = %v, want ARP", eth.EthernetType)
-		}
-		arpLayer := parsed.Layer(layers.LayerTypeARP)
-		if arpLayer == nil {
-			t.Fatal("missing ARP layer")
-		}
-		arp := arpLayer.(*layers.ARP)
-		if !bytes.Equal(arp.SourceProtAddress, vipAddr.AsSlice()) {
-			t.Errorf("ARP SourceProtAddress = %v, want %v", arp.SourceProtAddress, vipAddr.AsSlice())
-		}
-		if !bytes.Equal(arp.SourceHwAddress, hwAddr) {
-			t.Errorf("ARP SourceHwAddress = %v, want %v", arp.SourceHwAddress, hwAddr)
-		}
-		return nil
-	}
-	t.Cleanup(func() { linuxSendPacketWithProtocolFn = old })
-
-	c := &BasicConfigurer{
-		IPConfiguration: &IPConfiguration{
-			VIP:     vipAddr,
-			Netmask: net.CIDRMask(24, 32),
-			Iface: net.Interface{
-				Name:         "lo",
-				HardwareAddr: hwAddr,
-			},
-		},
-	}
-
-	if got := c.configureAddress(); !got {
-		t.Fatal("configureAddress() = false, want true")
-	}
-}
-
-// TestBasicConfigurer_configureAddress_IPv4_SendARPFails verifies that when the
-// gratuitous ARP send fails, configureAddress still returns true and handles
-// the error gracefully via a warning log.
-func TestBasicConfigurer_configureAddress_IPv4_SendARPFails(t *testing.T) {
-	t.Parallel()
-	mockLogger(t)
-	mockExecCommand(t, func(_ string, _ ...string) *exec.Cmd { return exec.Command("true") })
-
-	old := linuxSendPacketWithProtocolFn
-	linuxSendPacketWithProtocolFn = func(_ net.Interface, _ []byte, _ uint16) error {
-		return errors.New("mock ARP send error")
-	}
-	t.Cleanup(func() { linuxSendPacketWithProtocolFn = old })
-
-	c := &BasicConfigurer{
-		IPConfiguration: &IPConfiguration{
-			VIP:     netip.MustParseAddr("192.168.1.100"),
-			Netmask: net.CIDRMask(24, 32),
-			Iface: net.Interface{
-				Name:         "lo",
-				HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
-			},
-		},
-	}
-
-	if got := c.configureAddress(); !got {
-		t.Fatal("configureAddress() = false, want true even when ARP send fails")
+	if !errors.Is(err, syscall.ENODEV) && !errors.Is(err, syscall.EINVAL) {
+		t.Errorf("sendPacketLinux() error = %v, want ENODEV or EINVAL", err)
 	}
 }
 
 // ---------------------------------------------------------------------------
-// configureAddress
+// privileged end-to-end coverage against the real `ip` command
 // ---------------------------------------------------------------------------
 
 func TestBasicConfigurer_configureAddress_RequiresRoot(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("test must run as non-root to verify permission checks")
 	}
-
-	conf := zap.NewNop()
-	log = conf.Sugar()
+	mockLogger(t)
 
 	c := &BasicConfigurer{
 		IPConfiguration: &IPConfiguration{
@@ -656,49 +798,16 @@ func TestBasicConfigurer_configureAddress_RequiresRoot(t *testing.T) {
 		},
 	}
 
-	// Should fail due to lack of privileges
-	result := c.configureAddress()
-	if result {
+	if c.configureAddress() {
 		t.Error("configureAddress() should fail without root privileges")
 	}
 }
-
-func TestBasicConfigurer_configureAddress_NonexistentInterface(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("configureAddress tests require root privileges")
-	}
-
-	conf := zap.NewNop()
-	log = conf.Sugar()
-
-	c := &BasicConfigurer{
-		IPConfiguration: &IPConfiguration{
-			VIP:     netip.MustParseAddr("192.0.2.1"),
-			Netmask: net.CIDRMask(24, 32),
-			Iface: net.Interface{
-				Name:         "nonexistent999",
-				HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
-			},
-		},
-	}
-
-	result := c.configureAddress()
-	if result {
-		t.Error("configureAddress() should fail for non-existent interface")
-	}
-}
-
-// ---------------------------------------------------------------------------
-// deconfigureAddress
-// ---------------------------------------------------------------------------
 
 func TestBasicConfigurer_deconfigureAddress_RequiresRoot(t *testing.T) {
 	if os.Getuid() == 0 {
 		t.Skip("test must run as non-root to verify permission checks")
 	}
-
-	conf := zap.NewNop()
-	log = conf.Sugar()
+	mockLogger(t)
 
 	c := &BasicConfigurer{
 		IPConfiguration: &IPConfiguration{
@@ -711,20 +820,26 @@ func TestBasicConfigurer_deconfigureAddress_RequiresRoot(t *testing.T) {
 		},
 	}
 
-	// Should fail due to lack of privileges
-	result := c.deconfigureAddress()
-	if result {
+	if c.deconfigureAddress() {
 		t.Error("deconfigureAddress() should fail without root privileges")
 	}
 }
 
-func TestBasicConfigurer_deconfigureAddress_NonexistentInterface(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("deconfigureAddress tests require root privileges")
+// requireIPCommand skips the test when the `ip` binary is unavailable, so the
+// privileged tests do not fail merely because iproute2 is not installed.
+func requireIPCommand(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("ip"); err != nil {
+		t.Skip("the ip command is not available: ", err)
 	}
+}
 
-	conf := zap.NewNop()
-	log = conf.Sugar()
+func TestBasicConfigurer_runAddressConfiguration_NonexistentInterface(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("runAddressConfiguration tests require root privileges")
+	}
+	mockLogger(t)
+	requireIPCommand(t)
 
 	c := &BasicConfigurer{
 		IPConfiguration: &IPConfiguration{
@@ -737,241 +852,104 @@ func TestBasicConfigurer_deconfigureAddress_NonexistentInterface(t *testing.T) {
 		},
 	}
 
-	result := c.deconfigureAddress()
-	if result {
-		t.Error("deconfigureAddress() should fail for non-existent interface")
-	}
-}
-
-// ---------------------------------------------------------------------------
-// runAddressConfiguration
-// ---------------------------------------------------------------------------
-
-func TestBasicConfigurer_runAddressConfiguration_Add(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("runAddressConfiguration tests require root privileges")
-	}
-
-	conf := zap.NewNop()
-	log = conf.Sugar()
-
-	c := &BasicConfigurer{
-		IPConfiguration: &IPConfiguration{
-			VIP:     netip.MustParseAddr("192.0.2.1"),
-			Netmask: net.CIDRMask(24, 32),
-			Iface: net.Interface{
-				Name:         "nonexistent999",
-				HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
-			},
-		},
-	}
-
-	// Should fail for non-existent interface
-	result := c.runAddressConfiguration("add")
-	if result {
-		t.Error("runAddressConfiguration(add) should fail for non-existent interface")
-	}
-}
-
-func TestBasicConfigurer_runAddressConfiguration_Delete(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("runAddressConfiguration tests require root privileges")
-	}
-
-	conf := zap.NewNop()
-	log = conf.Sugar()
-
-	c := &BasicConfigurer{
-		IPConfiguration: &IPConfiguration{
-			VIP:     netip.MustParseAddr("192.0.2.1"),
-			Netmask: net.CIDRMask(24, 32),
-			Iface: net.Interface{
-				Name:         "nonexistent999",
-				HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
-			},
-		},
-	}
-
-	// Should fail for non-existent interface
-	result := c.runAddressConfiguration("delete")
-	if result {
-		t.Error("runAddressConfiguration(delete) should fail for non-existent interface")
-	}
-}
-
-// ---------------------------------------------------------------------------
-// runAddressConfiguration - test success path
-// ---------------------------------------------------------------------------
-
-func TestBasicConfigurer_runAddressConfiguration_SuccessPath(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("runAddressConfiguration tests require root privileges")
-	}
-
-	conf := zap.NewNop()
-	log = conf.Sugar()
-
-	// Get the loopback interface
-	lo, err := net.InterfaceByName("lo")
-	if err != nil {
-		t.Skip("loopback interface not available")
-	}
-
-	testIP := netip.MustParseAddr("192.0.2.77")
-	c := &BasicConfigurer{
-		IPConfiguration: &IPConfiguration{
-			VIP:     testIP,
-			Netmask: net.CIDRMask(32, 32),
-			Iface: net.Interface{
-				Index:        lo.Index,
-				Name:         lo.Name,
-				HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
-			},
-		},
-	}
-
-	// Ensure cleanup
-	defer c.runAddressConfiguration("delete")
-
-	// Test successful add
-	if result := c.runAddressConfiguration("add"); result {
-		t.Log("runAddressConfiguration(add) succeeded")
-		// Clean up
-		c.runAddressConfiguration("delete")
-	} else {
-		t.Log("runAddressConfiguration(add) failed (may be due to system restrictions)")
-	}
-}
-
-// ---------------------------------------------------------------------------
-// Integration test: configure and deconfigure on loopback (requires root)
-// ---------------------------------------------------------------------------
-
-func TestBasicConfigurer_Integration_RealInterfaceAddRemove(t *testing.T) {
-	if os.Getuid() != 0 {
-		t.Skip("integration test requires root privileges")
-	}
-
-	conf := zap.NewNop()
-	log = conf.Sugar()
-
-	// Find a real network interface (not loopback) with proper MAC
-	ifaces, err := net.Interfaces()
-	if err != nil {
-		t.Fatalf("failed to get network interfaces: %v", err)
-	}
-
-	var testIface *net.Interface
-	for i := range ifaces {
-		iface := &ifaces[i]
-		if iface.Flags&net.FlagUp != 0 &&
-			iface.HardwareAddr != nil &&
-			len(iface.HardwareAddr) == 6 &&
-			iface.HardwareAddr.String() != "00:00:00:00:00:00" &&
-			iface.Name != "lo" {
-			testIface = iface
-			break
-		}
-	}
-
-	if testIface == nil {
-		t.Skip("no suitable network interface found for testing")
-	}
-
-	testIP := netip.MustParseAddr("192.0.2.88")
-	c := &BasicConfigurer{
-		IPConfiguration: &IPConfiguration{
-			VIP:     testIP,
-			Netmask: net.CIDRMask(32, 32),
-			Iface:   *testIface,
-		},
-	}
-
-	// Ensure cleanup
-	defer c.deconfigureAddress()
-
-	// Test: Add the address
-	if !c.configureAddress() {
-		t.Log("Note: configureAddress failed (may be due to system restrictions)")
-		return
-	}
-
-	t.Log("Successfully configured address with ARP")
-
-	// Verify the address was added
-	if !c.queryAddress() {
-		t.Error("queryAddress returned false after successful configureAddress")
-	}
-
-	// Test: Remove the address
-	if !c.deconfigureAddress() {
-		t.Error("deconfigureAddress failed after successful configureAddress")
-	} else {
-		// Verify removal
-		if c.queryAddress() {
-			t.Error("queryAddress returned true after deconfigureAddress")
+	for _, action := range []string{"add", "delete"} {
+		if c.runAddressConfiguration(action) {
+			t.Errorf("runAddressConfiguration(%s) should fail for a non-existent interface", action)
 		}
 	}
 }
 
+// TestBasicConfigurer_Integration_LoopbackAddRemove drives the real `ip`
+// command end to end for both address families.
 func TestBasicConfigurer_Integration_LoopbackAddRemove(t *testing.T) {
 	if os.Getuid() != 0 {
 		t.Skip("integration test requires root privileges")
 	}
+	mockLogger(t)
+	requireIPCommand(t)
 
-	conf := zap.NewNop()
-	log = conf.Sugar()
-
-	// Get the loopback interface
 	lo, err := net.InterfaceByName("lo")
 	if err != nil {
 		t.Fatalf("failed to get loopback interface: %v", err)
 	}
 
-	// Use a TEST-NET address that's unlikely to conflict
-	testIP := netip.MustParseAddr("192.0.2.99")
+	tests := []struct {
+		name string
+		vip  string
+		mask net.IPMask
+	}{
+		{name: "IPv4", vip: "192.0.2.99", mask: net.CIDRMask(32, 32)},     // TEST-NET-1
+		{name: "IPv6", vip: "2001:db8::99", mask: net.CIDRMask(128, 128)}, // RFC 3849
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &BasicConfigurer{
+				IPConfiguration: &IPConfiguration{
+					VIP:     netip.MustParseAddr(tt.vip),
+					Netmask: tt.mask,
+					Iface: net.Interface{
+						Index:        lo.Index,
+						MTU:          lo.MTU,
+						Name:         lo.Name,
+						HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+						Flags:        lo.Flags,
+					},
+				},
+			}
+			defer c.deconfigureAddress()
+
+			// Announcing on loopback cannot work, but the address must still be
+			// added and the failure must be swallowed.
+			if !c.configureAddress() {
+				t.Fatal("configureAddress() = false, want true")
+			}
+			if !c.queryAddress() {
+				t.Error("queryAddress() = false after a successful configureAddress()")
+			}
+			if !c.deconfigureAddress() {
+				t.Fatal("deconfigureAddress() = false, want true")
+			}
+			if c.queryAddress() {
+				t.Error("queryAddress() = true after a successful deconfigureAddress()")
+			}
+		})
+	}
+}
+
+// TestBasicConfigurer_Integration_RealInterfaceAddRemove exercises the full
+// path, including the raw socket send, on a real Ethernet interface.
+func TestBasicConfigurer_Integration_RealInterfaceAddRemove(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("integration test requires root privileges")
+	}
+	mockLogger(t)
+	requireIPCommand(t)
+
+	testIface := firstEthernetInterface(t)
+	if testIface == nil || testIface.Name == "lo" {
+		t.Skip("no suitable network interface found for testing")
+	}
 
 	c := &BasicConfigurer{
 		IPConfiguration: &IPConfiguration{
-			VIP:     testIP,
-			Netmask: net.CIDRMask(32, 32), // /32 for single host
-			Iface: net.Interface{
-				Index:        lo.Index,
-				MTU:          lo.MTU,
-				Name:         lo.Name,
-				HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55}, // Fake MAC for loopback
-				Flags:        lo.Flags,
-			},
+			VIP:     netip.MustParseAddr("192.0.2.88"),
+			Netmask: net.CIDRMask(32, 32),
+			Iface:   *testIface,
 		},
 	}
+	defer c.deconfigureAddress()
 
-	// Ensure cleanup even if test fails
-	defer func() {
-		// Try to remove the address in case it was added
-		c.deconfigureAddress()
-	}()
-
-	// Test: Add the address
 	if !c.configureAddress() {
-		t.Log("Note: configureAddress failed (may be due to system restrictions or address already exists)")
-	} else {
-		t.Log("Successfully configured address")
-
-		// Verify the address was added by querying
-		if !c.queryAddress() {
-			t.Error("queryAddress returned false after successful configureAddress")
-		}
-
-		// Test: Remove the address
-		if !c.deconfigureAddress() {
-			t.Error("deconfigureAddress failed after successful configureAddress")
-		} else {
-			t.Log("Successfully deconfigured address")
-
-			// Verify the address was removed
-			if c.queryAddress() {
-				t.Error("queryAddress returned true after successful deconfigureAddress")
-			}
-		}
+		t.Fatal("configureAddress() = false, want true")
+	}
+	if !c.queryAddress() {
+		t.Error("queryAddress() = false after a successful configureAddress()")
+	}
+	if !c.deconfigureAddress() {
+		t.Fatal("deconfigureAddress() = false, want true")
+	}
+	if c.queryAddress() {
+		t.Error("queryAddress() = true after a successful deconfigureAddress()")
 	}
 }

--- a/ipmanager/basicConfigurer_linux_test.go
+++ b/ipmanager/basicConfigurer_linux_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"os/exec"
 	"syscall"
 	"testing"
 
@@ -211,6 +212,147 @@ func TestSendPacketLinux_EmptyPacket(t *testing.T) {
 	// May succeed or fail, but should not panic
 	if err != nil {
 		t.Logf("sendPacketLinux with empty packet returned: %v", err)
+	}
+}
+
+func TestBasicConfigurer_linkLocalAddress(t *testing.T) {
+	t.Parallel()
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		t.Fatalf("failed to get interfaces: %v", err)
+	}
+
+	for i := range ifaces {
+		iface := ifaces[i]
+		addrs, err := iface.Addrs()
+		if err != nil {
+			continue
+		}
+		for _, addr := range addrs {
+			ip, _, err := net.ParseCIDR(addr.String())
+			if err != nil || ip == nil || ip.To4() != nil || !ip.IsLinkLocalUnicast() {
+				continue
+			}
+
+			c := &BasicConfigurer{
+				IPConfiguration: &IPConfiguration{Iface: iface},
+			}
+			got, err := c.linkLocalAddress()
+			if err != nil {
+				t.Fatalf("linkLocalAddress() error for %s: %v", iface.Name, err)
+			}
+			if !got.Equal(ip) {
+				t.Fatalf("linkLocalAddress() = %s, want %s", got, ip)
+			}
+			return
+		}
+	}
+
+	t.Skip("no IPv6 link-local address available on this machine")
+}
+
+func TestBasicConfigurer_linkLocalAddress_MissingInterface(t *testing.T) {
+	t.Parallel()
+
+	c := &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			Iface: net.Interface{Name: "definitely-not-a-real-interface"},
+		},
+	}
+
+	_, err := c.linkLocalAddress()
+	if err == nil {
+		t.Fatal("linkLocalAddress() expected an error for a missing interface, got nil")
+	}
+}
+
+func mockLogger(t *testing.T) {
+	old := log
+	log = zap.NewNop().Sugar()
+	t.Cleanup(func() { log = old })
+}
+
+func mockExecCommand(t *testing.T, fn func(string, ...string) *exec.Cmd) {
+	old := execCommand
+	execCommand = fn
+	t.Cleanup(func() { execCommand = old })
+}
+
+func mockIPv6Send(t *testing.T, fn func(net.Interface, []byte, uint16) error) {
+	old := linuxSendPacketWithProtocolFn
+	linuxSendPacketWithProtocolFn = fn
+	t.Cleanup(func() { linuxSendPacketWithProtocolFn = old })
+}
+
+func TestBasicConfigurer_configureAddress_IPv6(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		iface     net.Interface
+		wantSend  bool
+		sendCheck func(net.Interface, []byte, uint16) error
+	}{
+		{
+			name:     "success",
+			iface:    net.Interface{Name: "lo"},
+			wantSend: true,
+			sendCheck: func(iface net.Interface, packetData []byte, protocol uint16) error {
+				if protocol != syscall.ETH_P_IPV6 {
+					t.Fatalf("wrong protocol: got %d want %d", protocol, syscall.ETH_P_IPV6)
+				}
+				return nil
+			},
+		},
+		{
+			name:     "no-link-local",
+			iface:    net.Interface{Name: "loopback-test"},
+			wantSend: false,
+			sendCheck: func(iface net.Interface, packetData []byte, protocol uint16) error {
+				t.Fatal("send should not be called when no IPv6 link-local address is available")
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockLogger(t)
+			mockExecCommand(t, func(name string, args ...string) *exec.Cmd { return exec.Command("true") })
+			mockIPv6Send(t, tt.sendCheck)
+
+			c := &BasicConfigurer{
+				IPConfiguration: &IPConfiguration{
+					VIP:     netip.MustParseAddr("2001:db8::10"),
+					Netmask: net.CIDRMask(64, 128),
+					Iface:   tt.iface,
+				},
+			}
+
+			if !c.configureAddress() {
+				t.Fatal("configureAddress() = false, want true")
+			}
+		})
+	}
+}
+
+func TestBasicConfigurer_runAddressConfiguration_ErrorExit(t *testing.T) {
+	mockLogger(t)
+	mockExecCommand(t, func(name string, args ...string) *exec.Cmd {
+		return exec.Command("sh", "-c", "exit 1")
+	})
+
+	c := &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			VIP:     netip.MustParseAddr("2001:db8::10"),
+			Netmask: net.CIDRMask(64, 128),
+			Iface:   net.Interface{Name: "lo"},
+		},
+	}
+
+	if c.runAddressConfiguration("add") {
+		t.Fatal("runAddressConfiguration() = true, want false")
 	}
 }
 

--- a/ipmanager/basicConfigurer_test.go
+++ b/ipmanager/basicConfigurer_test.go
@@ -246,3 +246,56 @@ func TestBasicConfigurer_createGratuitousARP(t *testing.T) {
 		t.Errorf("ARP destination protocol address = %v, want %v", arp.DstProtAddress, c.VIP.AsSlice())
 	}
 }
+
+func TestBasicConfigurer_createGratuitousNA(t *testing.T) {
+	t.Parallel()
+
+	c := &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			VIP: netip.MustParseAddr("2001:db8::10"),
+			Iface: net.Interface{
+				HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+			},
+		},
+	}
+	sourceIP := net.ParseIP("fe80::1")
+
+	packet, err := c.createGratuitousNA(sourceIP)
+	if err != nil {
+		t.Fatalf("createGratuitousNA() error = %v", err)
+	}
+
+	parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
+	eth := parsed.Layer(layers.LayerTypeEthernet).(*layers.Ethernet)
+	wantMulticast := net.HardwareAddr{0x33, 0x33, 0x00, 0x00, 0x00, 0x01}
+	if !bytes.Equal(eth.DstMAC, wantMulticast) {
+		t.Errorf("Ethernet destination MAC = %v, want %v", eth.DstMAC, wantMulticast)
+	}
+	if eth.EthernetType != layers.EthernetTypeIPv6 {
+		t.Errorf("Ethernet type = %v, want IPv6", eth.EthernetType)
+	}
+
+	ipv6 := parsed.Layer(layers.LayerTypeIPv6).(*layers.IPv6)
+	if ipv6.HopLimit != 255 {
+		t.Errorf("IPv6 hop limit = %d, want 255", ipv6.HopLimit)
+	}
+	if !ipv6.SrcIP.Equal(sourceIP) || !ipv6.DstIP.Equal(net.ParseIP("ff02::1")) {
+		t.Errorf("IPv6 addresses = %s -> %s, want %s -> ff02::1", ipv6.SrcIP, ipv6.DstIP, sourceIP)
+	}
+
+	icmp := parsed.Layer(layers.LayerTypeICMPv6).(*layers.ICMPv6)
+	if icmp.TypeCode.Type() != layers.ICMPv6TypeNeighborAdvertisement {
+		t.Errorf("ICMPv6 type = %v, want Neighbor Advertisement", icmp.TypeCode.Type())
+	}
+	na := parsed.Layer(layers.LayerTypeICMPv6NeighborAdvertisement).(*layers.ICMPv6NeighborAdvertisement)
+	if na.Flags != 0x20 {
+		t.Errorf("NA flags = 0x%x, want Override flag 0x20", na.Flags)
+	}
+	if !net.IP(na.TargetAddress).Equal(c.VIP.AsSlice()) {
+		t.Errorf("NA target = %s, want %s", na.TargetAddress, c.VIP)
+	}
+	if len(na.Options) != 1 || na.Options[0].Type != layers.ICMPv6OptTargetAddress ||
+		!bytes.Equal(na.Options[0].Data, c.Iface.HardwareAddr) {
+		t.Errorf("NA target link-layer option = %#v, want interface MAC", na.Options)
+	}
+}

--- a/ipmanager/basicConfigurer_test.go
+++ b/ipmanager/basicConfigurer_test.go
@@ -2,13 +2,30 @@ package ipmanager
 
 import (
 	"bytes"
+	"encoding/binary"
+	"errors"
 	"net"
 	"net/netip"
 	"testing"
 
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/layers"
+	"go.uber.org/zap"
 )
+
+// mockLogger silences the package logger for the duration of a test.
+func mockLogger(t *testing.T) {
+	old := log
+	log = zap.NewNop().Sugar()
+	t.Cleanup(func() { log = old })
+}
+
+// mockSerialize replaces the packet serializer, so tests can force a failure.
+func mockSerialize(t *testing.T, fn func(gopacket.SerializeBuffer, gopacket.SerializeOptions, ...gopacket.SerializableLayer) error) {
+	old := serializePacketLayers
+	serializePacketLayers = fn
+	t.Cleanup(func() { serializePacketLayers = old })
+}
 
 func testIPConfiguration(vip string) *IPConfiguration {
 	return &IPConfiguration{
@@ -297,5 +314,146 @@ func TestBasicConfigurer_createGratuitousNA(t *testing.T) {
 	if len(na.Options) != 1 || na.Options[0].Type != layers.ICMPv6OptTargetAddress ||
 		!bytes.Equal(na.Options[0].Data, c.Iface.HardwareAddr) {
 		t.Errorf("NA target link-layer option = %#v, want interface MAC", na.Options)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// createGratuitousNA - checksum and error paths
+// ---------------------------------------------------------------------------
+
+// icmpv6ChecksumValid recomputes the Internet checksum over the IPv6
+// pseudo-header and the ICMPv6 message. Because the message still carries its
+// own checksum, a correct packet sums to zero.
+func icmpv6ChecksumValid(src, dst net.IP, payload []byte) bool {
+	pseudo := make([]byte, 0, 40+len(payload))
+	pseudo = append(pseudo, src.To16()...)
+	pseudo = append(pseudo, dst.To16()...)
+	var length [4]byte
+	binary.BigEndian.PutUint32(length[:], uint32(len(payload)))
+	pseudo = append(pseudo, length[:]...)
+	pseudo = append(pseudo, 0, 0, 0, byte(layers.IPProtocolICMPv6))
+	pseudo = append(pseudo, payload...)
+
+	if len(pseudo)%2 == 1 {
+		pseudo = append(pseudo, 0)
+	}
+
+	var sum uint32
+	for i := 0; i < len(pseudo); i += 2 {
+		sum += uint32(binary.BigEndian.Uint16(pseudo[i : i+2]))
+	}
+	for sum>>16 != 0 {
+		sum = (sum & 0xffff) + (sum >> 16)
+	}
+	return uint16(^sum) == 0
+}
+
+func TestBasicConfigurer_createGratuitousNA_Checksum(t *testing.T) {
+	t.Parallel()
+
+	c := &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			VIP: netip.MustParseAddr("2001:db8::10"),
+			Iface: net.Interface{
+				HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+			},
+		},
+	}
+	sourceIP := net.ParseIP("fe80::1")
+
+	packet, err := c.createGratuitousNA(sourceIP)
+	if err != nil {
+		t.Fatalf("createGratuitousNA() error = %v", err)
+	}
+
+	parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
+	icmpLayer := parsed.Layer(layers.LayerTypeICMPv6)
+	if icmpLayer == nil {
+		t.Fatal("missing ICMPv6 layer")
+	}
+	icmp := icmpLayer.(*layers.ICMPv6)
+	if icmp.Checksum == 0 {
+		t.Fatal("ICMPv6 checksum is zero, SetNetworkLayerForChecksum had no effect")
+	}
+
+	// The ICMPv6 message is everything after the 14 byte Ethernet header and
+	// the 40 byte IPv6 header.
+	const l2l3 = 14 + 40
+	if len(packet) <= l2l3 {
+		t.Fatalf("packet is only %d bytes, too short to hold an ICMPv6 message", len(packet))
+	}
+	if !icmpv6ChecksumValid(sourceIP, net.ParseIP("ff02::1"), packet[l2l3:]) {
+		t.Errorf("ICMPv6 checksum 0x%04x does not validate over the IPv6 pseudo-header", icmp.Checksum)
+	}
+}
+
+func TestBasicConfigurer_createGratuitousNA_SerializeFails(t *testing.T) {
+	wantErr := errors.New("mock serialize error")
+	mockSerialize(t, func(gopacket.SerializeBuffer, gopacket.SerializeOptions, ...gopacket.SerializableLayer) error {
+		return wantErr
+	})
+
+	c := &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			VIP: netip.MustParseAddr("2001:db8::10"),
+			Iface: net.Interface{
+				HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+			},
+		},
+	}
+
+	if _, err := c.createGratuitousNA(net.ParseIP("fe80::1")); !errors.Is(err, wantErr) {
+		t.Fatalf("createGratuitousNA() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestBasicConfigurer_createGratuitousARP_SerializeFails(t *testing.T) {
+	wantErr := errors.New("mock serialize error")
+	mockSerialize(t, func(gopacket.SerializeBuffer, gopacket.SerializeOptions, ...gopacket.SerializableLayer) error {
+		return wantErr
+	})
+
+	c := &BasicConfigurer{IPConfiguration: testIPConfiguration("192.168.1.10")}
+
+	if _, err := c.createGratuitousARP(); !errors.Is(err, wantErr) {
+		t.Fatalf("createGratuitousARP() error = %v, want %v", err, wantErr)
+	}
+}
+
+// TestBasicConfigurer_createGratuitousARP_IPv4In6 pins down that a
+// ::ffff:a.b.c.d VIP still yields the 4 byte protocol address that
+// ProtAddressSize promises.
+func TestBasicConfigurer_createGratuitousARP_IPv4In6(t *testing.T) {
+	t.Parallel()
+
+	c := &BasicConfigurer{
+		IPConfiguration: &IPConfiguration{
+			VIP:     netip.MustParseAddr("::ffff:192.0.2.1"),
+			Netmask: net.CIDRMask(24, 32),
+			Iface: net.Interface{
+				Name:         "test0",
+				HardwareAddr: net.HardwareAddr{0x00, 0x11, 0x22, 0x33, 0x44, 0x55},
+			},
+		},
+	}
+
+	packet, err := c.createGratuitousARP()
+	if err != nil {
+		t.Fatalf("createGratuitousARP() error = %v", err)
+	}
+
+	parsed := gopacket.NewPacket(packet, layers.LayerTypeEthernet, gopacket.Default)
+	arpLayer := parsed.Layer(layers.LayerTypeARP)
+	if arpLayer == nil {
+		t.Fatal("missing ARP layer")
+	}
+	arp := arpLayer.(*layers.ARP)
+
+	want := net.ParseIP("192.0.2.1").To4()
+	if !bytes.Equal(arp.SourceProtAddress, want) {
+		t.Errorf("ARP SourceProtAddress = %v, want %v", arp.SourceProtAddress, want)
+	}
+	if !bytes.Equal(arp.DstProtAddress, want) {
+		t.Errorf("ARP DstProtAddress = %v, want %v", arp.DstProtAddress, want)
 	}
 }

--- a/ipmanager/basicConfigurer_windows_test.go
+++ b/ipmanager/basicConfigurer_windows_test.go
@@ -8,16 +8,8 @@ import (
 	"net/netip"
 	"testing"
 
-	"go.uber.org/zap"
 	"golang.org/x/sys/windows"
 )
-
-// mockLogger silences the package logger for the duration of a test.
-func mockLogger(t *testing.T) {
-	old := log
-	log = zap.NewNop().Sugar()
-	t.Cleanup(func() { log = old })
-}
 
 // ---------------------------------------------------------------------------
 // test helpers

--- a/ipmanager/ip_manager.go
+++ b/ipmanager/ip_manager.go
@@ -31,11 +31,11 @@ type IPManager struct {
 }
 
 func getMask(vip netip.Addr, mask int) net.IPMask {
-	if vip.Is4() { //IPv4
+	if vip.Is4() || vip.Is4In6() { //IPv4
 		if mask > 0 && mask < 33 {
 			return net.CIDRMask(mask, 32)
 		}
-		var ip net.IP = vip.AsSlice()
+		var ip net.IP = vip.Unmap().AsSlice()
 		return ip.DefaultMask()
 	}
 	return net.CIDRMask(mask, 128) //IPv6
@@ -58,6 +58,9 @@ func NewIPManager(conf *vipconfig.Config, states <-chan bool) (m *IPManager, err
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse VIP address: %w", err)
 	}
+	// Normalise ::ffff:a.b.c.d to a.b.c.d so that the rest of the code can rely
+	// on Is4/Is6 to pick the ARP or the Neighbor Advertisement path.
+	vip = vip.Unmap()
 	vipMask := getMask(vip, conf.Mask)
 	netIface, err := getNetIface(conf.Iface)
 	if err != nil {

--- a/ipmanager/ip_manager_test.go
+++ b/ipmanager/ip_manager_test.go
@@ -111,6 +111,10 @@ func TestGetMask_IPv4_ValidRange(t *testing.T) {
 		{"IPv4 /16", netip.MustParseAddr("10.0.0.1"), 16, "ffff0000"},
 		{"IPv6 /64", netip.MustParseAddr("2001:db8::1"), 64, "ffffffffffffffff0000000000000000"},
 		{"IPv6 /128", netip.MustParseAddr("2001:db8::1"), 128, "ffffffffffffffffffffffffffffffff"},
+		// Is6 reports true for ::ffff:a.b.c.d, but it is an IPv4 address and
+		// must get a 32 bit mask, not a 128 bit one.
+		{"IPv4-in-IPv6 /24", netip.MustParseAddr("::ffff:192.0.2.1"), 24, "ffffff00"},
+		{"IPv4-in-IPv6 /32", netip.MustParseAddr("::ffff:192.0.2.1"), 32, "ffffffff"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -133,6 +137,7 @@ func TestGetMask_IPv4_OutOfRange(t *testing.T) {
 		{"IPv4 negative", netip.MustParseAddr("192.168.1.1"), -1, "negative mask"},
 		{"IPv4 > 32", netip.MustParseAddr("192.168.1.1"), 33, "mask > 32"},
 		{"IPv4 zero", netip.MustParseAddr("192.168.1.1"), 0, "zero mask"},
+		{"IPv4-in-IPv6 zero", netip.MustParseAddr("::ffff:192.0.2.1"), 0, "zero mask falls back to the default mask"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Issue:
In current implementation, vip-manager doesn't send Neighbor Advertisement (NA)  after IPv6 bound. After a VIP moves to a new node, neighboring devices (routers, other servers) may still remember the old MAC address, so traffic keeps going to the old node and the service breaks.

Solution:  
After binding the IPv6 VIP on the new node, we actively send a NA to all neighbors to tell them the new MAC address.This way, traffic switches to the new node immediately without waiting for cache timeouts. The existing gratuitous ARP logic for IPv4 remains unchanged.